### PR TITLE
fix: add match-state validation before prediction

### DIFF
--- a/application.py
+++ b/application.py
@@ -1000,6 +1000,38 @@ if st.session_state.page == "Analysis":
         crr = score / overs if overs > 0 else 0
         rrr = (runs_left * 6) / balls_left if balls_left > 0 else 0
 
+        # ---- MATCH-STATE VALIDATION (Issue #31) ----
+        # Guard 1: batting team has already reached or crossed the target
+        if runs_left <= 0:
+            st.success(
+                f"🏆 **Match Over** — **{batting_team}** have already reached the target! "
+                f"No prediction needed."
+            )
+            st.stop()
+
+        # Guard 2: no balls remaining — innings is over, batting team fell short
+        if balls_left <= 0:
+            st.error(
+                f"⏱️ **Match Over** — No balls remaining. **{bowling_team}** win! "
+                f"No prediction needed."
+            )
+            st.stop()
+
+        # Guard 3: RRR physically impossible (> 36 runs/over = 6 runs every ball)
+        if rrr > 36.0:
+            st.error(
+                f"⚠️ **Invalid match state** — Required Run Rate is **{round(rrr, 2)} runs/over**, "
+                f"which is physically impossible in cricket. Please check your inputs."
+            )
+            st.stop()
+
+        # Guard 4: RRR extremely high (> 24 runs/over) — warn but allow prediction
+        if rrr > 24.0:
+            st.warning(
+                f"⚠️ **Extreme match state** — Required Run Rate is **{round(rrr, 2)} runs/over**. "
+                f"This is a very unlikely scenario; the prediction below may be less reliable."
+            )
+
         input_df = pd.DataFrame({
             'batting_team': [batting_team],
             'bowling_team': [bowling_team],


### PR DESCRIPTION
## Summary

Fixes #31

This PR adds match-state validation before running the win probability model in `application.py`.

Previously, the app calculated values such as `runs_left`, `balls_left`, `crr`, and `rrr`, then directly passed them into `pipe.predict_proba()` without checking whether the match situation was valid or realistic.

Now, the app validates important cricket match-state conditions before calling the ML model. Impossible or already-decided match situations are handled with clear Streamlit messages instead of producing misleading probability outputs.

## Problem

The model was being called even for extreme or invalid cricket situations.

For example:

- batting team has already reached or crossed the target
- no balls are remaining
- required run rate is physically impossible
- required run rate is extremely high and outside normal match conditions

In such cases, the model may still return a number, but that probability may not be meaningful because the input is outside realistic IPL match states.

## Changes Made

- Added validation inside the `if analyze:` block in `application.py`
- Added a match-over guard when `runs_left <= 0`
- Added a no-balls-left guard when `balls_left <= 0`
- Added a hard stop when `rrr > 36.0` because this is physically impossible
- Added a warning when `rrr > 24.0` because this is an extreme match state
- Kept normal prediction flow unchanged for valid match situations
- Kept `input_df` construction unchanged
- Kept `pipe.predict_proba()` unchanged
- No model retraining or ML pipeline changes were made

## Validation Logic Added

### 1. Batting team already reached target

If `runs_left <= 0`, the app now shows a match-over success message and stops prediction.

### 2. No balls remaining

If `balls_left <= 0`, the app now shows a match-over error message and stops prediction.

### 3. Physically impossible required run rate

If `rrr > 36.0`, the app shows an error and stops prediction because scoring more than 36 runs per over is not physically possible in normal cricket scoring.

### 4. Extreme required run rate

If `rrr > 24.0`, the app shows a warning but still allows prediction to continue. This keeps the model usable while informing users that the match state is extremely unlikely and prediction reliability may be lower.

## Why this is useful

ML models work best when the inputs are similar to the data they were trained on. If impossible or extreme cricket situations are passed into the model, the output may look like a valid probability but may not be meaningful.

This improves:

- cricket logic correctness
- user trust in the prediction
- reliability of model inputs
- handling of edge cases before prediction
- clarity for users when the match state is already decided or unrealistic

This change makes CricScope more honest and reliable by preventing misleading win probability outputs for impossible situations.

## Testing

I tested the following scenarios locally in the Streamlit app:

- [x] Valid match state: prediction runs normally
- [x] Impossible required run rate: error message is shown and prediction is stopped
- [x] Extreme required run rate: warning message is shown and prediction still runs
- [x] Existing prediction cards still appear for valid inputs
- [x] No model, dataset, or pipeline changes were made

## Screenshots

### Valid match state

<img width="1919" height="1005" alt="cricscope-valid-match-prediction" src="https://github.com/user-attachments/assets/c8d75d0a-7271-4cd0-a034-ff285acab8d6" />


### Impossible required run rate

<img width="1917" height="983" alt="cricscope-impossible-rrr-error" src="https://github.com/user-attachments/assets/83749057-2b3e-45d8-b822-f1d3afde6ffb" />


### Extreme required run rate warning

<img width="1919" height="1007" alt="cricscope-extreme-rrr-warning" src="https://github.com/user-attachments/assets/cf18c35c-7fc6-4d85-8e29-394dfc2895c0" />


## Notes

This PR does not retrain the model, add new model types, or modify the ML pipeline. It only adds validation before prediction so unrealistic match states are handled more clearly.

## AI Assistance Disclosure

I used AI assistance to understand the existing prediction flow and plan the match-state validation approach. I reviewed and tested the final changes locally before submitting this PR.