### PR TITLE
Fix hardcoded city inference in prediction pipeline

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,5 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/CricScopeNew.iml
+++ b/.idea/CricScopeNew.iml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.venv" />
+    </content>
+    <orderEntry type="jdk" jdkName="Python 3.13 (CricScopeNew)" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.13 (CricScopeNew)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/CricScopeNew.iml" filepath="$PROJECT_DIR$/.idea/CricScopeNew.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/application.py
+++ b/application.py
@@ -852,6 +852,12 @@ def compute_win_rates():
 
 win_stats = compute_win_rates()
 
+# Cities used in model features; keep inference options aligned with dataset values.
+@st.cache_data
+def get_city_options():
+    matches = pd.read_csv("matches.csv")
+    return sorted(matches["city"].dropna().unique().tolist())
+
 # -----------------------------------
 # MODEL
 # -----------------------------------
@@ -1146,6 +1152,7 @@ if st.session_state.page == "Analysis":
     st.markdown('<div style="height: clamp(16px, 4vw, 32px);"></div>', unsafe_allow_html=True)
 
     teams = list(team_data.keys())
+    city_options = get_city_options()
 
     # ---- INPUT SECTION ----
     st.markdown("""
@@ -1162,6 +1169,8 @@ if st.session_state.page == "Analysis":
         st.markdown('<div class="input-label">Teams</div>', unsafe_allow_html=True)
         batting_team = st.selectbox("Batting Team", teams, key="bat")
         bowling_team = st.selectbox("Bowling Team", [t for t in teams if t != batting_team], key="bowl")
+        # City is an encoded categorical model feature; choose from known dataset values at inference time.
+        city = st.selectbox("City", city_options, key="city")
         st.markdown('</div>', unsafe_allow_html=True)
 
     with col2:
@@ -1266,7 +1275,8 @@ if st.session_state.page == "Analysis":
         input_df = pd.DataFrame({
             'batting_team': [batting_team],
             'bowling_team': [bowling_team],
-            'city': ['Mumbai'],
+            # Pass selected city instead of a fixed value to avoid train-inference mismatch.
+            'city': [city],
             'runs_left': [runs_left],
             'balls_left': [balls_left],
             'wickets': [10 - wickets],


### PR DESCRIPTION
## Description

Fixed the issue where the city feature was hardcoded to 'Mumbai' during inference.

### Changes made

* Added dynamic city selection
* Passed selected city into prediction pipeline
* Preserved compatibility with OneHotEncoder

### Why this fix?

The model was trained on multiple city values, but inference always used 'Mumbai', causing biased predictions and train-inference mismatch.

Fixes #15
