### PR TITLE
[fix] City feature hardcoded to 'Mumbai' in prediction input #59

### DIFF
--- a/application.py
+++ b/application.py
@@ -1393,6 +1393,21 @@ if st.session_state.page == "Analysis":
         st.markdown('<div class="input-label">Select Teams</div>', unsafe_allow_html=True)
         batting_team = st.selectbox("Batting Team", teams, key="bat")
         bowling_team = st.selectbox("Bowling Team", [t for t in teams if t != batting_team], key="bowl")
+        
+        # City selection
+        st.markdown('<div style="height:16px;"></div>', unsafe_allow_html=True)
+        st.markdown('<div class="input-label">Match Venue</div>', unsafe_allow_html=True)
+        
+        # IPL cities - common venues used in the dataset
+        cities = [
+            "Mumbai", "Bangalore", "Delhi", "Chennai", "Kolkata", 
+            "Hyderabad", "Jaipur", "Chandigarh", "Ahmedabad", 
+            "Pune", "Lucknow", "Visakhapatnam", "Indore",
+            "Durban", "Johannesburg", "Cape Town", "Centurion",  # Some historical matches abroad (checked the dataset as well)
+            "Dubai", "Abu Dhabi", "Sharjah"  # some UAE venues mentioned in dataset
+        ]
+        
+        city = st.selectbox("City / Stadium Location", cities, key="city")
         st.markdown('</div>', unsafe_allow_html=True)
 
     with col2:
@@ -1532,7 +1547,7 @@ if st.session_state.page == "Analysis":
         input_df = pd.DataFrame({
             'batting_team': [batting_team],
             'bowling_team': [bowling_team],
-            'city': ['Mumbai'],
+            'city': [city],  # Here is the mAin fix, from hardcoded mumbai -> dynamic city input
             'runs_left': [runs_left],
             'balls_left': [balls_left],
             'wickets': [10 - wickets],


### PR DESCRIPTION
Updated the Match Configuration flow in application.py to remove the hardcoded city dependency from the prediction pipeline. 

it is the Fix of the issue #59.

- A new Streamlit st.selectbox was added in the Analysis page UI to capture the match venue/city from a predefined list of dataset-supported locations.

- In the UI layer, the change introduces a new labeled venue section with supporting st.markdown() blocks for spacing and input labeling, followed by city = st.selectbox("City / Stadium Location", cities, key="city").

- In the prediction input construction, the input_df payload was updated to replace the static 'city': ['Mumbai'] assignment with the dynamically selected city value from the new selectbox. 