### PR TITLE
feat: add Stats page — head-to-head records, player performance & venue analysis

### DIFF
--- a/pages/stats.py
+++ b/pages/stats.py
@@ -1,0 +1,308 @@
+import pandas as pd
+import streamlit as st
+
+#  page config 
+st.set_page_config(
+    page_title="CricScope · Stats",
+    page_icon="📊",
+    layout="wide",
+)
+
+# shared CSS (matches application.py dark-gold aesthetic) 
+st.markdown("""
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600;700&family=DM+Sans:wght@300;400;500&family=DM+Mono&display=swap');
+
+html, body, [class*="css"] {
+    background-color: #0a0a0f;
+    color: #e8e0d0;
+    font-family: 'DM Sans', sans-serif;
+}
+
+.gold { color: #d4af37; }
+
+.glass-card {
+    background: rgba(255,255,255,0.03);
+    border: 1px solid rgba(212,175,55,0.18);
+    border-radius: 16px;
+    padding: 1.5rem 2rem;
+    margin-bottom: 1.2rem;
+    backdrop-filter: blur(12px);
+}
+
+.section-title {
+    font-family: 'Cormorant Garamond', serif;
+    font-size: 1.6rem;
+    font-weight: 600;
+    color: #d4af37;
+    margin-bottom: 0.4rem;
+    letter-spacing: 0.04em;
+}
+
+.stat-pill {
+    display: inline-block;
+    background: rgba(212,175,55,0.12);
+    border: 1px solid rgba(212,175,55,0.3);
+    border-radius: 20px;
+    padding: 0.25rem 0.9rem;
+    font-family: 'DM Mono', monospace;
+    font-size: 0.82rem;
+    color: #d4af37;
+    margin: 0.2rem;
+}
+
+.win-bar-wrap {
+    background: rgba(255,255,255,0.05);
+    border-radius: 8px;
+    height: 10px;
+    width: 100%;
+    margin: 4px 0 12px 0;
+    overflow: hidden;
+}
+.win-bar-fill {
+    height: 10px;
+    border-radius: 8px;
+    background: linear-gradient(90deg, #d4af37, #f0d060);
+}
+
+h1, h2, h3 { font-family: 'Cormorant Garamond', serif; color: #d4af37; }
+</style>
+""", unsafe_allow_html=True)
+
+
+#  data loading 
+@st.cache_data
+def load_data():
+    matches = pd.read_csv("matches.csv")
+    deliveries = pd.read_csv("deliveries.csv")
+    return matches, deliveries
+
+
+matches, deliveries = load_data()
+
+#  page header 
+st.markdown("""
+<div style='text-align:center; padding: 2rem 0 1rem 0;'>
+    <h1 style='font-size:3rem; margin-bottom:0;'>📊 CricScope Stats</h1>
+    <p style='color:#888; font-size:1rem; margin-top:0.3rem;'>
+        Historical team performance · Head-to-head records · Venue analysis
+    </p>
+</div>
+""", unsafe_allow_html=True)
+
+#  team list 
+all_teams = sorted(set(matches["team1"].dropna()) | set(matches["team2"].dropna()))
+
+
+# SECTION 1 — Head-to-Head
+
+st.markdown('<div class="section-title">⚔️ Head-to-Head Record</div>', unsafe_allow_html=True)
+
+col1, col2 = st.columns(2)
+with col1:
+    team_a = st.selectbox("Team A", all_teams, index=all_teams.index("Mumbai Indians") if "Mumbai Indians" in all_teams else 0, key="h2h_a")
+with col2:
+    remaining = [t for t in all_teams if t != team_a]
+    team_b = st.selectbox("Team B", remaining, index=remaining.index("Chennai Super Kings") if "Chennai Super Kings" in remaining else 0, key="h2h_b")
+
+# filter h2h matches
+h2h = matches[
+    ((matches["team1"] == team_a) & (matches["team2"] == team_b)) |
+    ((matches["team1"] == team_b) & (matches["team2"] == team_a))
+].copy()
+
+if h2h.empty:
+    st.info("No head-to-head matches found between these two teams.")
+else:
+    total = len(h2h)
+    a_wins = (h2h["winner"] == team_a).sum()
+    b_wins = (h2h["winner"] == team_b).sum()
+    no_result = total - a_wins - b_wins
+
+    a_pct = round(a_wins / total * 100, 1) if total else 0
+    b_pct = round(b_wins / total * 100, 1) if total else 0
+
+    ca, cb, cc = st.columns(3)
+    with ca:
+        st.markdown(f"""
+        <div class="glass-card" style="text-align:center;">
+            <div style="font-size:2.2rem; font-weight:700; color:#d4af37;">{a_wins}</div>
+            <div style="color:#aaa; font-size:0.85rem;">{team_a} Wins</div>
+            <div class="win-bar-wrap"><div class="win-bar-fill" style="width:{a_pct}%;"></div></div>
+            <span class="stat-pill">{a_pct}%</span>
+        </div>
+        """, unsafe_allow_html=True)
+    with cb:
+        st.markdown(f"""
+        <div class="glass-card" style="text-align:center;">
+            <div style="font-size:2.2rem; font-weight:700; color:#888;">{total}</div>
+            <div style="color:#aaa; font-size:0.85rem;">Total Matches</div>
+            <div style="margin-top:0.5rem; color:#666; font-size:0.8rem;">No Result: {no_result}</div>
+        </div>
+        """, unsafe_allow_html=True)
+    with cc:
+        st.markdown(f"""
+        <div class="glass-card" style="text-align:center;">
+            <div style="font-size:2.2rem; font-weight:700; color:#d4af37;">{b_wins}</div>
+            <div style="color:#aaa; font-size:0.85rem;">{team_b} Wins</div>
+            <div class="win-bar-wrap"><div class="win-bar-fill" style="width:{b_pct}%;"></div></div>
+            <span class="stat-pill">{b_pct}%</span>
+        </div>
+        """, unsafe_allow_html=True)
+
+    # recent 5 matches
+    st.markdown("**Recent Encounters**")
+    recent = h2h[["Season", "date", "venue", "winner", "win_by_runs", "win_by_wickets"]].tail(5).iloc[::-1]
+    recent.columns = ["Season", "Date", "Venue", "Winner", "Win by Runs", "Win by Wickets"]
+    st.dataframe(
+        recent,
+        use_container_width=True,
+        hide_index=True,
+    )
+
+st.markdown("---")
+
+# SECTION 2 — Top Run Scorers & Wicket Takers per Team 
+st.markdown('<div class="section-title">🏏 Player Performance by Team</div>', unsafe_allow_html=True)
+
+selected_team = st.selectbox("Select Team", all_teams, key="player_team")
+
+# batting — runs scored while batting for selected team
+# deliveries has batting_team column
+team_batting = deliveries[deliveries["batting_team"] == selected_team]
+top_batters = (
+    team_batting.groupby("batsman")["batsman_runs"]
+    .sum()
+    .sort_values(ascending=False)
+    .head(10)
+    .reset_index()
+)
+top_batters.columns = ["Player", "Runs"]
+
+# bowling — wickets taken while bowling against selected team's opponent
+# wicket_kind excludes run outs (credited to fielder not bowler)
+team_bowling = deliveries[deliveries["bowling_team"] == selected_team]
+wicket_deliveries = team_bowling[
+    team_bowling["dismissal_kind"].notna() &
+    (~team_bowling["dismissal_kind"].isin(["run out", "retired hurt", "obstructing the field"]))
+]
+top_bowlers = (
+    wicket_deliveries.groupby("bowler")["dismissal_kind"]
+    .count()
+    .sort_values(ascending=False)
+    .head(10)
+    .reset_index()
+)
+top_bowlers.columns = ["Player", "Wickets"]
+
+col_bat, col_bowl = st.columns(2)
+
+with col_bat:
+    st.markdown(f"""
+    <div class="glass-card">
+        <div style="font-size:1rem; color:#d4af37; font-weight:600; margin-bottom:0.8rem;">
+            🏏 Top Run Scorers — {selected_team}
+        </div>
+    </div>
+    """, unsafe_allow_html=True)
+
+    for i, row in top_batters.iterrows():
+        bar_pct = int(row["Runs"] / top_batters["Runs"].max() * 100)
+        rank_color = "#d4af37" if i == 0 else "#888"
+        st.markdown(f"""
+        <div style="display:flex; align-items:center; margin-bottom:0.5rem; gap:0.8rem;">
+            <span style="color:{rank_color}; font-family:'DM Mono'; width:1.2rem;">#{i+1}</span>
+            <div style="flex:1;">
+                <div style="display:flex; justify-content:space-between;">
+                    <span style="font-size:0.88rem;">{row['Player']}</span>
+                    <span class="stat-pill">{int(row['Runs'])} runs</span>
+                </div>
+                <div class="win-bar-wrap" style="margin:3px 0 0 0;">
+                    <div class="win-bar-fill" style="width:{bar_pct}%;"></div>
+                </div>
+            </div>
+        </div>
+        """, unsafe_allow_html=True)
+
+with col_bowl:
+    st.markdown(f"""
+    <div class="glass-card">
+        <div style="font-size:1rem; color:#d4af37; font-weight:600; margin-bottom:0.8rem;">
+            🎯 Top Wicket Takers — {selected_team}
+        </div>
+    </div>
+    """, unsafe_allow_html=True)
+
+    for i, row in top_bowlers.iterrows():
+        bar_pct = int(row["Wickets"] / top_bowlers["Wickets"].max() * 100)
+        rank_color = "#d4af37" if i == 0 else "#888"
+        st.markdown(f"""
+        <div style="display:flex; align-items:center; margin-bottom:0.5rem; gap:0.8rem;">
+            <span style="color:{rank_color}; font-family:'DM Mono'; width:1.2rem;">#{i+1}</span>
+            <div style="flex:1;">
+                <div style="display:flex; justify-content:space-between;">
+                    <span style="font-size:0.88rem;">{row['Player']}</span>
+                    <span class="stat-pill">{int(row['Wickets'])} wkts</span>
+                </div>
+                <div class="win-bar-wrap" style="margin:3px 0 0 0;">
+                    <div class="win-bar-fill" style="width:{bar_pct}%;"></div>
+                </div>
+            </div>
+        </div>
+        """, unsafe_allow_html=True)
+
+st.markdown("---")
+
+# SECTION 3 — Venue-wise Team Performance
+
+st.markdown('<div class="section-title">🏟️ Venue Performance</div>', unsafe_allow_html=True)
+
+venue_team = st.selectbox("Select Team for Venue Analysis", all_teams, key="venue_team")
+
+# matches where team played (home or away)
+team_matches = matches[
+    (matches["team1"] == venue_team) | (matches["team2"] == venue_team)
+].copy()
+team_matches["won"] = (team_matches["winner"] == venue_team).astype(int)
+
+venue_stats = (
+    team_matches.groupby("venue")
+    .agg(
+        Played=("won", "count"),
+        Won=("won", "sum"),
+    )
+    .reset_index()
+)
+venue_stats["Lost"] = venue_stats["Played"] - venue_stats["Won"]
+venue_stats["Win %"] = (venue_stats["Won"] / venue_stats["Played"] * 100).round(1)
+venue_stats = venue_stats.sort_values("Played", ascending=False).head(10)
+
+st.markdown(f"**Top venues by matches played — {venue_team}**")
+
+for _, row in venue_stats.iterrows():
+    win_pct = row["Win %"]
+    bar_color = "#d4af37" if win_pct >= 50 else "#8b5e3c"
+    st.markdown(f"""
+    <div class="glass-card" style="padding:1rem 1.5rem; margin-bottom:0.7rem;">
+        <div style="display:flex; justify-content:space-between; margin-bottom:0.4rem;">
+            <span style="font-size:0.9rem; color:#e8e0d0;">{row['venue']}</span>
+            <div>
+                <span class="stat-pill">P {int(row['Played'])}</span>
+                <span class="stat-pill">W {int(row['Won'])}</span>
+                <span class="stat-pill">L {int(row['Lost'])}</span>
+                <span class="stat-pill" style="color:#f0d060;">{win_pct}%</span>
+            </div>
+        </div>
+        <div class="win-bar-wrap">
+            <div style="height:10px; border-radius:8px; width:{win_pct}%;
+                        background:linear-gradient(90deg, {bar_color}, #f0d060);"></div>
+        </div>
+    </div>
+    """, unsafe_allow_html=True)
+
+#  footer 
+st.markdown("""
+<div style='text-align:center; padding:2rem 0; color:#444; font-size:0.8rem;'>
+    CricScope Stats · IPL 2008–2020 · Data via Kaggle
+</div>
+""", unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
Adds a new **Stats** page (`pages/stats.py`) to CricScope with three 
analytics panels built purely on existing `matches.csv` and 
`deliveries.csv` — no new dependencies.

Closes #97

---

## Type of change
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactor

---

## Changes made
- `pages/stats.py` — new Streamlit multipage file with 3 sections:

**1. Head-to-Head Record**
- Select any two IPL teams → total matches, wins, win %, no results
- Gold gradient win percentage bars
- Recent 5 encounters table with season, venue, winner, margin

**2. Player Performance by Team**
- Top 10 run scorers for any selected team (aggregated from deliveries.csv)
- Top 10 wicket takers (correctly excludes run outs, retired hurt)
- Gold ranked progress bars for both

**3. Venue Performance**
- Win/loss record across top 10 venues for any selected team
- Win % bar with color coding (gold ≥50%, amber <50%)

---

## How to test
1. Place `matches.csv` and `deliveries.csv` in project root
2. `pip install streamlit pandas`
3. `streamlit run application.py`
4. Click **stats** in the left sidebar

---

## Design
Matches the existing dark gold glassmorphism aesthetic exactly —
same `#0a0a0f` background, `#d4af37` gold palette, Cormorant Garamond
+ DM Sans + DM Mono fonts, and glass cards as `application.py`.

---

## Screenshots
> Stats page running via `streamlit run application.py`:

<img width="1918" height="911" alt="Screenshot 2026-05-23 225741" src="https://github.com/user-attachments/assets/2cdaf7ea-f779-4f4b-963a-9f2d46018f16" />
<img width="1918" height="908" alt="Screenshot 2026-05-23 230408" src="https://github.com/user-attachments/assets/8f073712-20b3-460c-90c2-733e894bc438" />


---

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] My code follows the existing code style
- [x] No new dependencies added
- [x] Tested locally on Windows with both CSV files present
- [x] UI matches dark gold design system

---

## GSSoC Declaration
- [x] This contribution is made under GSSoC '26
- [x] I have not plagiarised code from other repositories