### PR TITLE
fix(perf): cache pipeline load with st.cache_resource to avoid repeated disk I/O

### DIFF
--- a/application.py
+++ b/application.py
@@ -2,6 +2,7 @@ import streamlit as st
 import pandas as pd
 import numpy as np
 import time
+import joblib
 
 from sklearn.compose import ColumnTransformer
 from sklearn.preprocessing import OneHotEncoder
@@ -688,7 +689,25 @@ def train_model():
     pipe.fit(X, y)
     return pipe
 
-pipe = train_model()
+
+@st.cache_resource
+def load_pipeline():
+    """Load the pre-trained pipeline from disk exactly once per server process.
+
+    Uses joblib for efficient deserialization. @st.cache_resource ensures the
+    object is shared across all Streamlit sessions and reruns so disk I/O and
+    deserialization happen only once at startup, not on every user interaction.
+
+    If pipe.pkl is missing, falls back to training from raw data via
+    train_model() so the app remains functional during development.
+    """
+    try:
+        return joblib.load("pipe.pkl")
+    except FileNotFoundError:
+        return train_model()
+
+
+pipe = load_pipeline()
 
 # -----------------------------------
 # SIDEBAR


### PR DESCRIPTION
## Summary

Fixes #100

### Root cause

`application.py` called `train_model()` at module level on every cold server start. `train_model()` reads `matches.csv` and `deliveries.csv`, merges and processes match-level data, and trains a `LogisticRegression` pipeline entirely from scratch before any prediction could run. Because Streamlit reruns the full script on every user interaction, any session that triggered a cache miss would repeat all of this work.

A pre-trained `pipe.pkl` artifact is already committed to the repository, and `joblib` is listed in `requirements.txt`, but neither was wired up for serving predictions.

### Changes in `application.py`

1. **Added `import joblib`** (already in `requirements.txt`, no new dependency).

2. **Added `load_pipeline()`** decorated with `@st.cache_resource`:

```python
@st.cache_resource
def load_pipeline():
    try:
        return joblib.load("pipe.pkl")
    except FileNotFoundError:
        return train_model()
```

`@st.cache_resource` ensures the object is instantiated exactly once per server process and shared across all user sessions and Streamlit reruns. Subsequent prediction calls reuse the same in-memory pipeline with zero disk I/O.

3. **Graceful fallback**: if `pipe.pkl` is absent (e.g. a fresh clone without the artifact), `load_pipeline()` falls back to `train_model()` so the app stays functional.

4. **Replaced `pipe = train_model()`** with `pipe = load_pipeline()`.

`train_model()` is retained as the training utility for regenerating `pipe.pkl` when the model or dataset changes.

### Before / After

| | Before | After |
|---|---|---|
| Cold start | Reads 2 CSVs + trains model | Deserializes `pipe.pkl` via joblib |
| Subsequent reruns | Cached by `@st.cache_resource` on `train_model` | Cached by `@st.cache_resource` on `load_pipeline` |
| Missing artifact | Works (trains from data) | Falls back to `train_model()` |

## Test plan

- [ ] Run `streamlit run application.py` and open Match Analysis
- [ ] Click Run Analysis several times; confirm prediction latency is consistent and low
- [ ] Rename `pipe.pkl` temporarily and restart the app; confirm it falls back to `train_model()` without crashing
- [ ] Restore `pipe.pkl` and confirm it loads on next startup