### PR TITLE
fix(analysis): add missing team mappings and guard against unsupported teams

### DIFF
--- a/application.py
+++ b/application.py
@@ -631,7 +631,61 @@ team_data = {
     "Sunrisers Hyderabad": {
         "logo": "http://assets.designhill.com/design-blog/wp-content/uploads/2025/03/8-4.jpg",
         "abbr": "SRH", "color": "#f97316"
-    }
+    },
+    # Franchises created after training data cutoff
+    "Lucknow Super Giants": {
+        "logo": "https://bcciplayerimages.s3.ap-south-1.amazonaws.com/ipl/LSG/Logos/Roundbig/LSGbig.png",
+        "abbr": "LSG", "color": "#00A3E0"
+    },
+    "Gujarat Titans": {
+        "logo": "https://bcciplayerimages.s3.ap-south-1.amazonaws.com/ipl/GT/Logos/Roundbig/GTbig.png",
+        "abbr": "GT", "color": "#1C2951"
+    },
+    # Defunct franchises that appear in the training data
+    "Deccan Chargers": {
+        "logo": "",
+        "abbr": "DCH", "color": "#1B3A7A"
+    },
+    "Pune Warriors India": {
+        "logo": "",
+        "abbr": "PWI", "color": "#00205B"
+    },
+    "Rising Pune Supergiant": {
+        "logo": "",
+        "abbr": "RPS", "color": "#8B2FC9"
+    },
+    "Gujarat Lions": {
+        "logo": "",
+        "abbr": "GL", "color": "#E8501A"
+    },
+    "Kochi Tuskers Kerala": {
+        "logo": "",
+        "abbr": "KTK", "color": "#1B5E20"
+    },
+}
+
+# Maps the UI display name for each team to the name string the pipeline was
+# trained on. Punjab Kings was renamed from Kings XI Punjab in 2021 but the
+# training data uses the historical name, so the OneHotEncoder must receive it.
+# Lucknow Super Giants and Gujarat Titans joined after the training data cutoff
+# and are not represented in the encoder; they are mapped to None so the
+# prediction block can detect and warn about unsupported matchups.
+UI_TO_MODEL_NAME = {
+    "Chennai Super Kings":         "Chennai Super Kings",
+    "Delhi Capitals":              "Delhi Capitals",
+    "Punjab Kings":                "Kings XI Punjab",
+    "Kolkata Knight Riders":       "Kolkata Knight Riders",
+    "Mumbai Indians":              "Mumbai Indians",
+    "Rajasthan Royals":            "Rajasthan Royals",
+    "Royal Challengers Bangalore": "Royal Challengers Bangalore",
+    "Sunrisers Hyderabad":         "Sunrisers Hyderabad",
+    "Lucknow Super Giants":        None,
+    "Gujarat Titans":              None,
+    "Deccan Chargers":             "Deccan Chargers",
+    "Pune Warriors India":         "Pune Warriors",
+    "Rising Pune Supergiant":      "Rising Pune Supergiant",
+    "Gujarat Lions":               "Gujarat Lions",
+    "Kochi Tuskers Kerala":        "Kochi Tuskers Kerala",
 }
 
 # -----------------------------------
@@ -1000,9 +1054,31 @@ if st.session_state.page == "Analysis":
         crr = score / overs if overs > 0 else 0
         rrr = (runs_left * 6) / balls_left if balls_left > 0 else 0
 
+        # Translate UI names to the names the model was trained on.
+        bat_model_name  = UI_TO_MODEL_NAME.get(batting_team,  batting_team)
+        bowl_model_name = UI_TO_MODEL_NAME.get(bowling_team, bowling_team)
+
+        # Detect teams that have no representation in the training data.
+        # The OneHotEncoder uses handle_unknown='ignore', so these are encoded
+        # as all-zero vectors and the prediction may not reflect real dynamics.
+        unsupported = [t for t, n in
+                       [(batting_team, bat_model_name), (bowling_team, bowl_model_name)]
+                       if n is None]
+        if unsupported:
+            st.warning(
+                f"{' and '.join(unsupported)} "
+                + ("were" if len(unsupported) > 1 else "was")
+                + " not included in the model training data. "
+                "Win probability estimates for this matchup may not be accurate."
+            )
+        # Replace None with the raw UI name so the encoder handles it as an
+        # unknown category (zero-vector) without raising a KeyError.
+        bat_model_name  = bat_model_name  or batting_team
+        bowl_model_name = bowl_model_name or bowling_team
+
         input_df = pd.DataFrame({
-            'batting_team': [batting_team],
-            'bowling_team': [bowling_team],
+            'batting_team': [bat_model_name],
+            'bowling_team': [bowl_model_name],
             'city': ['Mumbai'],
             'runs_left': [runs_left],
             'balls_left': [balls_left],


### PR DESCRIPTION
## Summary

Fixes #98

### Problems addressed

**1. Missing teams in dropdown**

`team_data` only contained 8 of the 15 IPL franchises. Selecting Lucknow Super Giants, Gujarat Titans, Deccan Chargers, Pune Warriors India, Rising Pune Supergiant, Gujarat Lions, or Kochi Tuskers Kerala would either crash the app or silently fall through to a default team (line 942 fallback), confusing users.

**2. Wrong training-data name for Punjab Kings**

The pipeline was trained on `Kings XI Punjab` (the franchise name before its 2021 rebrand to Punjab Kings). `input_df` was built with the UI string `Punjab Kings`, which the `OneHotEncoder(handle_unknown='ignore')` silently zero-encodes, producing inaccurate win probabilities.

**3. No user warning for post-cutoff teams**

Lucknow Super Giants and Gujarat Titans were created after the training data cutoff. Users had no way to know the model had no information about these teams.

### Changes in `application.py`

**`team_data` (7 new entries)**

| Team | Status | Logo source |
|---|---|---|
| Lucknow Super Giants | Active | BCCI CDN |
| Gujarat Titans | Active | BCCI CDN |
| Deccan Chargers | Defunct | (placeholder) |
| Pune Warriors India | Defunct | (placeholder) |
| Rising Pune Supergiant | Defunct | (placeholder) |
| Gujarat Lions | Defunct | (placeholder) |
| Kochi Tuskers Kerala | Defunct | (placeholder) |

**`UI_TO_MODEL_NAME` dict (new)**

Maps every dropdown label to the exact string the `OneHotEncoder` was trained on:
- `"Punjab Kings"` → `"Kings XI Punjab"`
- `"Pune Warriors India"` → `"Pune Warriors"`
- `"Lucknow Super Giants"` → `None` (post-cutoff)
- `"Gujarat Titans"` → `None` (post-cutoff)
- All other 11 teams map to themselves

**Prediction block guard (new)**

```python
bat_model_name  = UI_TO_MODEL_NAME.get(batting_team,  batting_team)
bowl_model_name = UI_TO_MODEL_NAME.get(bowling_team, bowling_team)

unsupported = [t for t, n in [...] if n is None]
if unsupported:
    st.warning("... not included in model training data ...")

input_df = pd.DataFrame({
    'batting_team': [bat_model_name or batting_team],
    'bowling_team': [bowl_model_name or bowling_team],
    ...
})
```

The `None` fallback to the raw UI name lets the encoder handle the team as an unknown category (zero-vector) without raising a `KeyError`, while the `st.warning()` tells the user upfront that predictions for that matchup may not be reliable.

## Test plan

- [ ] Select Lucknow Super Giants as batting team and click Run Analysis: warning appears, prediction runs without crashing
- [ ] Select Gujarat Titans as bowling team: same warning and graceful prediction
- [ ] Select Punjab Kings: no warning, prediction uses Kings XI Punjab encoding internally
- [ ] Select Deccan Chargers, Pune Warriors India, Rising Pune Supergiant, Gujarat Lions, Kochi Tuskers Kerala: no warning (training data covers these), prediction runs correctly
- [ ] All 15 teams appear in both dropdowns without errors
- [ ] No regression for the original 8 active teams