### PR TITLE
fix(perf): remove @st.cache_resource from train_model and add load_pipeline

### DIFF
--- a/application.py
+++ b/application.py
@@ -2,6 +2,7 @@ import streamlit as st
 import pandas as pd
 import numpy as np
 import time
+import joblib
 
 from sklearn.compose import ColumnTransformer
 from sklearn.preprocessing import OneHotEncoder
@@ -637,7 +638,11 @@ team_data = {
 # -----------------------------------
 # MODEL
 # -----------------------------------
-@st.cache_resource
+
+# Training utility - intended for offline use to regenerate pipe.pkl.
+# Not decorated with @st.cache_resource because it should never run at
+# app startup in a deployed environment; load_pipeline() below is the
+# sole runtime entry point.
 def train_model():
     matches = pd.read_csv("matches.csv")
     deliveries = pd.read_csv("deliveries.csv")
@@ -680,15 +685,37 @@ def train_model():
         ('num', 'passthrough', ['runs_left', 'balls_left', 'wickets', 'target', 'crr', 'rrr'])
     ])
 
-    pipe = Pipeline([
+    trained = Pipeline([
         ('preprocessor', preprocessor),
         ('model', LogisticRegression(max_iter=1000))
     ])
 
-    pipe.fit(X, y)
-    return pipe
+    trained.fit(X, y)
+    return trained
 
-pipe = train_model()
+
+@st.cache_resource
+def load_pipeline():
+    """Load the prediction pipeline exactly once per server process.
+
+    Attempts to deserialise pipe.pkl via joblib (sub-second on any hardware).
+    If the artifact is absent (e.g. a fresh development clone), falls back to
+    train_model() and immediately serialises the result to pipe.pkl so that
+    every subsequent cold start is fast without manual intervention.
+
+    @st.cache_resource pins the returned object in Streamlit's resource cache,
+    meaning it is shared across all user sessions and reruns with no additional
+    disk I/O or training cost.
+    """
+    try:
+        return joblib.load("pipe.pkl")
+    except FileNotFoundError:
+        trained = train_model()
+        joblib.dump(trained, "pipe.pkl")
+        return trained
+
+
+pipe = load_pipeline()
 
 # -----------------------------------
 # SIDEBAR


### PR DESCRIPTION
## Summary

Fixes #99

### Root cause

`train_model()` was annotated with `@st.cache_resource` and called at module level (`pipe = train_model()`). On every cold start (server restart, Streamlit Cloud wake-up, cache clear), Streamlit executed the full function body: reading `matches.csv` + `deliveries.csv`, merging and engineering features across ~750k delivery rows, and fitting a `LogisticRegression` pipeline. This blocked app startup for a significant time with zero benefit, because a pre-trained `pipe.pkl` is already committed to the repository and `joblib` is listed in `requirements.txt`.

### What was wrong with using `@st.cache_resource` on `train_model()`

`@st.cache_resource` is designed for objects that are expensive to create and should be shared across sessions. Wrapping a full training pipeline in it means the expensive work runs unconditionally on every cold start instead of being bypassed by loading the artifact. The decorator provides session-sharing but does not prevent the initial training cost.

### Changes in `application.py`

**`train_model()` (demoted to offline utility)**
- Removed `@st.cache_resource`
- Renamed internal variable from `pipe` to `trained` to avoid shadowing the module-level name
- Added a comment marking it as an offline tool for regenerating `pipe.pkl`; it is no longer called at app startup

**`load_pipeline()` (new, `@st.cache_resource`)**
- Primary path: `joblib.load("pipe.pkl")` (sub-second deserialisation)
- Fallback: if `pipe.pkl` is absent, calls `train_model()` once and immediately writes the result back to `pipe.pkl` via `joblib.dump()`, so all subsequent cold starts use the fast path automatically
- `@st.cache_resource` pins the object across all sessions and reruns with no repeat disk I/O

**Call site**
- `pipe = train_model()` replaced with `pipe = load_pipeline()`

**`import joblib`** added (already in `requirements.txt`)

### Cold start comparison

| | Before | After |
|---|---|---|
| `pipe.pkl` present | Trains from CSV anyway (cache miss on first start) | Loads artifact in under 1s |
| `pipe.pkl` absent | Trains from CSV | Trains once, saves `pipe.pkl`, then fast on next start |
| Streamlit rerun | Reads from `@st.cache_resource` memory | Reads from `@st.cache_resource` memory |

## Test plan

- [ ] Delete `pipe.pkl`, restart the app: confirms fallback trains and writes `pipe.pkl`
- [ ] Restart again with `pipe.pkl` present: confirms sub-second startup, no CSV reads
- [ ] Run Analysis with valid inputs: confirms `pipe.predict_proba` returns correct probabilities
- [ ] Call `st.cache_resource.clear()` and reload: confirms `load_pipeline()` re-reads `pipe.pkl` cleanly