### PR TITLE
fix: replace hardcoded city with user-selected venue dropdown

### DIFF
--- a/application.py
+++ b/application.py
@@ -995,6 +995,9 @@ if st.session_state.page == "Analysis":
         st.markdown('<div class="input-label">Teams</div>', unsafe_allow_html=True)
         batting_team = st.selectbox("Batting Team", teams, key="bat")
         bowling_team = st.selectbox("Bowling Team", [t for t in teams if t != batting_team], key="bowl")
+        # Venue dropdown — populated from unique cities in training data
+        ipl_cities = sorted(matches['city'].dropna().unique().tolist())
+        city = st.selectbox("Venue / City", ipl_cities, index=ipl_cities.index('Mumbai'), key="city")
         st.markdown('</div>', unsafe_allow_html=True)
 
     with col2:
@@ -1099,7 +1102,7 @@ if st.session_state.page == "Analysis":
         input_df = pd.DataFrame({
             'batting_team': [batting_team],
             'bowling_team': [bowling_team],
-            'city': ['Mumbai'],
+            'city': [city],
             'runs_left': [runs_left],
             'balls_left': [balls_left],
             'wickets': [10 - wickets],


### PR DESCRIPTION
## Description
Fixes the hardcoded `'Mumbai'` city in the prediction input DataFrame. Previously every prediction used Mumbai as the venue regardless of where the match was actually being played, silently biasing all win probabilities toward Mumbai's historical match conditions.

**Changes:**
- Added a `Venue / City` selectbox in the Teams input card, populated from unique cities in `matches.csv` training data (32 IPL venues)
- Replaced `'city': ['Mumbai']` hardcode with `'city': [city]` using the user-selected value
- Dropdown defaults to `'Mumbai'` for backward compatibility

## Related Issue
Closes #105

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Files Changed
- `application.py` — 4 lines changed: added city selectbox and wired it to prediction DataFrame

## How to Test
1. Run `streamlit run application.py`
2. Navigate to the prediction section
3. Observe the new **Venue / City** dropdown in the Teams input card
4. Select a city other than Mumbai (e.g. Chennai)
5. Run Analysis — prediction now uses the selected venue instead of always using Mumbai

## Screenshots
N/A — the app has a pre-existing startup crash in `train_model()` at line 773 (`accuracy_score` called before `predictions` is defined — unrelated to this PR). Our change only adds 4 lines to the input section and prediction DataFrame. The diff is self-evident.

## Additional Context
The pre-existing error in `train_model()` (`predictions` used before `pipe.predict(X_test)` is called) causes the app to crash on startup locally. This is unrelated to this PR — our change is limited to the city dropdown addition and the single line fix in the prediction DataFrame.