### PR TITLE
Fix PBKS team-name mismatch for model inference

### DIFF
--- a/application.py
+++ b/application.py
@@ -1096,9 +1096,17 @@ if st.session_state.page == "Analysis":
         crr = score / overs if overs > 0 else 0
         rrr = (runs_left * 6) / balls_left if balls_left > 0 else 0
 
+        team_aliases = {
+            "Punjab Kings": "Kings XI Punjab",
+        }
+        batting_team_model = team_aliases.get(batting_team, batting_team)
+        bowling_team_model = team_aliases.get(bowling_team, bowling_team)
+        if batting_team_model != batting_team or bowling_team_model != bowling_team:
+            st.caption("Using historical team name for model compatibility.")
+
         input_df = pd.DataFrame({
-            'batting_team': [batting_team],
-            'bowling_team': [bowling_team],
+            'batting_team': [batting_team_model],
+            'bowling_team': [bowling_team_model],
             'city': ['Mumbai'],
             'runs_left': [runs_left],
             'balls_left': [balls_left],


### PR DESCRIPTION
Fixes #132\n\n- Canonicalizes "Punjab Kings" -> "Kings XI Punjab" before building the model input features\n- Adds a small UI note when canonicalization occurs\n\nThis prevents OneHotEncoder(handle_unknown=ignore) from silently zeroing the team identity for PBKS.