### PR TITLE
Update repository name from 'cricscope' to 'CricScope'

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,22 +24,22 @@
 
 <br/>
 
-![Contributors](https://img.shields.io/github/contributors/Arnav-Singh-5080/cricscope?style=for-the-badge)
-![Open Issues](https://img.shields.io/github/issues/Arnav-Singh-5080/cricscope?style=for-the-badge)
-![Last Commit](https://img.shields.io/github/last-commit/Arnav-Singh-5080/cricscope?style=for-the-badge)
+![Contributors](https://img.shields.io/github/contributors/Arnav-Singh-5080/CricScope?style=for-the-badge)
+![Open Issues](https://img.shields.io/github/issues/Arnav-Singh-5080/CricScope?style=for-the-badge)
+![Last Commit](https://img.shields.io/github/last-commit/Arnav-Singh-5080/CricScope?style=for-the-badge)
 
 <br/><br/>
 
-<a href="https://github.com/Arnav-Singh-5080/cricscope/stargazers">
-  <img src="https://img.shields.io/github/stars/Arnav-Singh-5080/cricscope?style=social" />
+<a href="https://github.com/Arnav-Singh-5080/CricScope/stargazers">
+  <img src="https://img.shields.io/github/stars/Arnav-Singh-5080/CricScope?style=social" />
 </a>
 &nbsp;
-<a href="https://github.com/Arnav-Singh-5080/cricscope/network/members">
-  <img src="https://img.shields.io/github/forks/Arnav-Singh-5080/cricscope?style=social" />
+<a href="https://github.com/Arnav-Singh-5080/CricScope/network/members">
+  <img src="https://img.shields.io/github/forks/Arnav-Singh-5080/CricScope?style=social" />
 </a>
 &nbsp;
-<a href="https://github.com/Arnav-Singh-5080/cricscope/issues">
-  <img src="https://img.shields.io/github/issues/Arnav-Singh-5080/cricscope?style=social" />
+<a href="https://github.com/Arnav-Singh-5080/CricScope/issues">
+  <img src="https://img.shields.io/github/issues/Arnav-Singh-5080/CricScope?style=social" />
 </a>
 
 </div>
@@ -51,7 +51,7 @@
 
 ## Live Demo
 
-<a href="https://cricscope-live.streamlit.app/" target="_blank">
+<a href="https://CricScope-live.streamlit.app/" target="_blank">
   <img src="https://img.shields.io/badge/Launch%20App-CricScope-d4af37?style=for-the-badge&logo=streamlit&logoColor=white" />
 </a>
 
@@ -210,7 +210,7 @@ trained on IPL ball-by-ball match data spanning IPL seasons from 2008–2020.
 </div>
 
 ```bash
-cricscope/
+CricScope/
 │
 ├── assets/
 │   ├── dashboard.png
@@ -250,8 +250,8 @@ https://www.kaggle.com/datasets/patrickb1912/ipl-complete-dataset-20082020
 ## 1 — Clone Repository
 
 ```bash
-git clone https://github.com/Arnav-Singh-5080/cricscope.git
-cd cricscope
+git clone https://github.com/Arnav-Singh-5080/CricScope.git
+cd CricScope
 ```
 
 ---
@@ -281,7 +281,7 @@ pip install -r requirements.txt
 ## 4 — Add Dataset
 
 ```text
-cricscope/
+CricScope/
 ├── app.py
 ├── matches.csv
 └── deliveries.csv
@@ -375,10 +375,10 @@ This repository welcomes:
 # 1. Fork the repository
 
 # 2. Clone your fork
-git clone https://github.com/<your-username>/cricscope.git
+git clone https://github.com/<your-username>/CricScope.git
 
 # 3. Move into project
-cd cricscope
+cd CricScope
 
 # 4. Create feature branch
 git checkout -b feature/your-feature-name


### PR DESCRIPTION
Closes #115
Changes:

Fixed repository clone URL casing from cricscope to CricScope across README.md
Standardized all 16 instances for consistent branding and contributor onboarding