### PR TITLE
feat: add dynamic venue selection for match predictions

### DIFF
--- a/application.py
+++ b/application.py
@@ -883,6 +883,16 @@ if st.session_state.page == "Analysis":
     st.markdown('<div style="height:32px;"></div>', unsafe_allow_html=True)
 
     teams = list(team_data.keys())
+    cities = [
+    "Mumbai",
+    "Delhi",
+    "Chennai",
+    "Bangalore",
+    "Kolkata",
+    "Hyderabad",
+    "Jaipur",
+    "Mohali"
+]
 
     # ---- INPUT SECTION ----
     st.markdown("""
@@ -904,6 +914,7 @@ if st.session_state.page == "Analysis":
     with col2:
         st.markdown('<div class="input-card">', unsafe_allow_html=True)
         st.markdown('<div class="input-label">Match State</div>', unsafe_allow_html=True)
+        city = st.selectbox("Match Venue", cities, key="city")
         target = st.number_input("Target Score", min_value=50, max_value=300, value=180, step=1)
         score = st.number_input("Current Score", min_value=0, max_value=target - 1, value=50, step=1)
         col_ov, col_wk = st.columns(2)
@@ -1003,7 +1014,7 @@ if st.session_state.page == "Analysis":
         input_df = pd.DataFrame({
             'batting_team': [batting_team],
             'bowling_team': [bowling_team],
-            'city': ['Mumbai'],
+            'city': [city],
             'runs_left': [runs_left],
             'balls_left': [balls_left],
             'wickets': [10 - wickets],


### PR DESCRIPTION
## Issue Fixed
Closes #139 

## Description
Added dynamic venue selection in Match Analysis instead of using a hardcoded city value.

## Changes Made
- Added match venue dropdown
- Passed selected city dynamically to the prediction model
- Improved realism and flexibility of match predictions

## Why This Matters
Venue conditions significantly impact cricket match outcomes, including:
- pitch behavior
- dew factor
- chasing difficulty
- bowling conditions

Since the ML pipeline already uses `city` as an input feature, this enhancement improves prediction quality and better utilizes the trained model features.


##Screenshot :

Before :

<img width="1906" height="1040" alt="image" src="https://github.com/user-attachments/assets/fc2d0fd1-79de-4fea-a29d-ee34c035790b" />


After : 

<img width="1905" height="1025" alt="image" src="https://github.com/user-attachments/assets/242635ba-8ffb-4936-b222-fcaeb57128b6" />

