### PR TITLE
feat: add ball-by-ball CSV export for win probability predictions (#113)

### DIFF
--- a/application.py
+++ b/application.py
@@ -1130,5 +1130,53 @@ if st.session_state.page == "Analysis":
                 </div>
             </div>
         """, unsafe_allow_html=True)
+        # ---- CSV EXPORT ----
+        st.markdown('<div style="height:20px;"></div>', unsafe_allow_html=True)
+
+        # Generate ball-by-ball predictions from current state to end of innings
+        rows = []
+        for ov in range(overs, 20):
+            for bl in range(1, 7):
+                total_balls_done = ov * 6 + bl
+                if total_balls_done <= overs * 6:
+                    continue  # skip already-played balls
+                if total_balls_done > 120:
+                    break
+
+                b_left = 120 - total_balls_done
+                c_score = score  # score stays same (projection from current state)
+                r_left = target - c_score
+                c_crr = c_score / (total_balls_done / 6) if total_balls_done > 0 else 0
+                c_rrr = (r_left * 6) / b_left if b_left > 0 else 0
+
+                proj_df = pd.DataFrame({
+                    'batting_team': [batting_team],
+                    'bowling_team': [bowling_team],
+                    'city': ['Mumbai'],
+                    'runs_left': [r_left],
+                    'balls_left': [b_left],
+                    'wickets': [10 - wickets],
+                    'target': [target],
+                    'crr': [c_crr],
+                    'rrr': [c_rrr]
+                })
+
+                proj_proba = pipe.predict_proba(proj_df)[0]
+                rows.append({
+                    "over": ov + 1,
+                    "ball": bl,
+                    "batting_team_prob": round(proj_proba[1] * 100, 2),
+                    "bowling_team_prob": round(proj_proba[0] * 100, 2)
+                })
+
+        export_df = pd.DataFrame(rows)
+
+        if not export_df.empty:
+            st.download_button(
+                label="⬇️ Download Ball-by-Ball Predictions (CSV)",
+                data=export_df.to_csv(index=False),
+                file_name=f"{batting_team}_vs_{bowling_team}_predictions.csv",
+                mime="text/csv"
+            )
 
     st.markdown('</div>', unsafe_allow_html=True)  # close main-pad


### PR DESCRIPTION
Closes #113

## Changes
- Added ball-by-ball CSV export button on the Match Analysis page
- Generates win probability projections for all remaining balls from current match state
- Columns: over, ball, batting_team_prob, bowling_team_prob
- Button appears below the Model Verdict card after running analysis

## Testing
- Ran match simulation locally (CSK vs DC)
- Verified download button appears after prediction
- Confirmed CSV downloads with correct 4 columns