### PR TITLE
fix: resolve static city bias by injecting dynamic venue selection in the User Interface

### DIFF
--- a/application.py
+++ b/application.py
@@ -899,6 +899,16 @@ if st.session_state.page == "Analysis":
         st.markdown('<div class="input-label">Teams</div>', unsafe_allow_html=True)
         batting_team = st.selectbox("Batting Team", teams, key="bat")
         bowling_team = st.selectbox("Bowling Team", [t for t in teams if t != batting_team], key="bowl")
+        cities = [
+            'Abu Dhabi', 'Ahmedabad', 'Bangalore', 'Bengaluru', 'Bloemfontein', 
+            'Cape Town', 'Centurion', 'Chandigarh', 'Chennai', 'Cuttack', 
+            'Delhi', 'Dharamsala', 'Durban', 'East London', 'Hyderabad', 
+            'Indore', 'Jaipur', 'Johannesburg', 'Kanpur', 'Kimberley', 
+            'Kochi', 'Kolkata', 'Mohali', 'Mumbai', 'Nagpur', 
+            'Port Elizabeth', 'Pune', 'Raipur', 'Rajkot', 'Ranchi', 
+            'Sharjah', 'Visakhapatnam'
+        ]
+        selected_city = st.selectbox("Select Host City", cities, index=cities.index('Mumbai'), key="city")
         st.markdown('</div>', unsafe_allow_html=True)
 
     with col2:
@@ -1003,7 +1013,7 @@ if st.session_state.page == "Analysis":
         input_df = pd.DataFrame({
             'batting_team': [batting_team],
             'bowling_team': [bowling_team],
-            'city': ['Mumbai'],
+            'city': [selected_city],
             'runs_left': [runs_left],
             'balls_left': [balls_left],
             'wickets': [10 - wickets],


### PR DESCRIPTION
### Description
This PR resolves the silent prediction bias where the application hardcoded `city: ['Mumbai']` into the prediction dataframe regardless of the actual match venue.

**Changes made:**
- Extracted the complete list of 32 unique cities from `matches.csv` (including international IPL venues) to safely populate the UI.
- Added a 'selectbox' in the Match Configuration column allowing users to select the host venue (defaulting to Mumbai to preserve the original visual flow).
- Updated the 'input_df' generation to dynamically pass the 'selected_city' variable into the Logistic Regression pipeline instead of the hardcoded string. 

Because the 'ColumnTransformer' utilizes 'OneHotEncoder(handle_unknown='ignore')', the model now correctly computes win probabilities weighted against the actual historical conditions of the selected city.