### PR TITLE
Fix incorrect balls_left calculation and dependent run rate calculations

### DIFF
--- a/application.py
+++ b/application.py
@@ -652,16 +652,23 @@ def train_model():
 
     df['current_score'] = df.groupby('match_id')['total_runs'].cumsum()
     df['runs_left'] = df['target'] - df['current_score']
-    df['balls_left'] = 120 - (df['over'] * 6 + df['ball'])
+    # Correct balls_left calculation using legal deliveries bowled:
+    # balls_bowled = ((over - 1) * 6) + ball
+    # and ensuring it is never negative.
+    balls_bowled = ((df['over'] - 1) * 6) + df['ball']
+    df['balls_left'] = (120 - balls_bowled).clip(lower=0)
 
     df['player_dismissed'] = df['player_dismissed'].notna().astype(int)
     df['wickets'] = df.groupby('match_id')['player_dismissed'].cumsum()
     df['wickets'] = 10 - df['wickets']
 
-    df['over'] = df['over'].replace(0, 0.1)
+    # Correct current run rate (crr) using correct overs bowled denominator:
+    # (over - 1) + (ball / 6)
+    overs_bowled = (df['over'] - 1) + (df['ball'] / 6)
+    df['crr'] = np.where(overs_bowled > 0, df['current_score'] / overs_bowled, 0.0)
 
-    df['crr'] = df['current_score'] / (df['over'] + df['ball'] / 6)
-    df['rrr'] = (df['runs_left'] * 6) / df['balls_left']
+    # Correct required run rate (rrr) avoiding division by zero when balls_left is 0
+    df['rrr'] = np.where(df['balls_left'] > 0, (df['runs_left'] * 6) / df['balls_left'], 0.0)
 
     df.replace([np.inf, -np.inf], np.nan, inplace=True)
 
@@ -908,7 +915,7 @@ if st.session_state.page == "Analysis":
         score = st.number_input("Current Score", min_value=0, max_value=target - 1, value=50, step=1)
         col_ov, col_wk = st.columns(2)
         with col_ov:
-            overs = st.slider("Overs Completed", min_value=1, max_value=19, value=10)
+            overs = st.slider("Overs Completed", min_value=0, max_value=20, value=10)
         with col_wk:
             wickets = st.number_input("Wickets Fallen", min_value=0, max_value=9, value=2)
         st.markdown('</div>', unsafe_allow_html=True)
@@ -996,9 +1003,9 @@ if st.session_state.page == "Analysis":
     # ---- PREDICTION OUTPUT ----
     if analyze:
         runs_left = target - score
-        balls_left = 120 - (overs * 6)
-        crr = score / overs if overs > 0 else 0
-        rrr = (runs_left * 6) / balls_left if balls_left > 0 else 0
+        balls_left = max(120 - (overs * 6), 0)
+        crr = score / overs if overs > 0 else 0.0
+        rrr = (runs_left * 6) / balls_left if balls_left > 0 else 0.0
 
         input_df = pd.DataFrame({
             'batting_team': [batting_team],
@@ -1014,10 +1021,17 @@ if st.session_state.page == "Analysis":
 
         with st.spinner(""):
             time.sleep(0.4)
-            proba = pipe.predict_proba(input_df)[0]
-
-        win = proba[1]
-        lose = proba[0]
+            # Edge-case handling for final ball/completed innings boundaries
+            if runs_left <= 0:
+                win = 1.0
+                lose = 0.0
+            elif balls_left <= 0:
+                win = 0.0
+                lose = 1.0
+            else:
+                proba = pipe.predict_proba(input_df)[0]
+                win = proba[1]
+                lose = proba[0]
 
         st.markdown('<div style="height:28px;"></div>', unsafe_allow_html=True)
         st.markdown("""

--- a/test_calculations.py
+++ b/test_calculations.py
@@ -1,0 +1,93 @@
+import unittest
+import pandas as pd
+import numpy as np
+
+# Helper functions replicating the implementation logic in application.py
+def calculate_balls_left_df(over, ball):
+    # Replicates pandas training logic
+    df = pd.DataFrame({'over': over, 'ball': ball})
+    balls_bowled = ((df['over'] - 1) * 6) + df['ball']
+    df['balls_left'] = (120 - balls_bowled).clip(lower=0)
+    return df['balls_left'].tolist()
+
+def calculate_crr_df(current_score, over, ball):
+    # Replicates pandas training logic
+    df = pd.DataFrame({'current_score': current_score, 'over': over, 'ball': ball})
+    overs_bowled = (df['over'] - 1) + (df['ball'] / 6)
+    df['crr'] = np.where(overs_bowled > 0, df['current_score'] / overs_bowled, 0.0)
+    return df['crr'].tolist()
+
+def calculate_rrr_df(runs_left, balls_left):
+    # Replicates pandas training logic
+    df = pd.DataFrame({'runs_left': runs_left, 'balls_left': balls_left})
+    df['rrr'] = np.where(df['balls_left'] > 0, (df['runs_left'] * 6) / df['balls_left'], 0.0)
+    return df['rrr'].tolist()
+
+def calculate_prediction_inputs(target, score, overs):
+    # Replicates streamlit/prediction logic
+    runs_left = target - score
+    balls_left = max(120 - (overs * 6), 0)
+    crr = score / overs if overs > 0 else 0.0
+    rrr = (runs_left * 6) / balls_left if balls_left > 0 else 0.0
+    return runs_left, balls_left, crr, rrr
+
+
+class TestCricScopeCalculations(unittest.TestCase):
+
+    def test_normal_innings_states(self):
+        # 1st over, 1st ball
+        self.assertEqual(calculate_balls_left_df([1], [1]), [119])
+        self.assertEqual(calculate_crr_df([1], [1], [1]), [6.0]) # 1 run off 1 ball => CRR = 6.0
+
+        # 10th over, 3rd ball (9.5 overs bowled)
+        self.assertEqual(calculate_balls_left_df([10], [3]), [63])
+        # 57 runs off 57 balls => CRR = 57 / 9.5 = 6.0
+        self.assertEqual(calculate_crr_df([57], [10], [3]), [6.0])
+
+        # RRR logic: 100 runs left, 63 balls left
+        self.assertAlmostEqual(calculate_rrr_df([100], [63])[0], 600 / 63, places=4)
+
+    def test_final_over_scenarios(self):
+        # 20th over, 1st ball
+        self.assertEqual(calculate_balls_left_df([20], [1]), [5])
+        
+        # 20th over, 6th ball (final ball of innings)
+        self.assertEqual(calculate_balls_left_df([20], [6]), [0])
+        self.assertEqual(calculate_crr_df([120], [20], [6]), [6.0]) # 120 runs off 20 overs => CRR = 6.0
+
+    def test_balls_left_capped_at_zero(self):
+        # 20th over, 7th ball (due to extra delivery)
+        self.assertEqual(calculate_balls_left_df([20], [7]), [0])
+        # 20th over, 9th ball
+        self.assertEqual(calculate_balls_left_df([20], [9]), [0])
+
+    def test_rrr_division_by_zero_handling(self):
+        # When balls_left = 0, RRR should be 0.0 (no division by zero or infinity)
+        self.assertEqual(calculate_rrr_df([10], [0]), [0.0])
+
+    def test_prediction_inputs_normal(self):
+        # 10 overs completed, target 180, score 80
+        runs_left, balls_left, crr, rrr = calculate_prediction_inputs(180, 80, 10)
+        self.assertEqual(runs_left, 100)
+        self.assertEqual(balls_left, 60)
+        self.assertEqual(crr, 8.0)
+        self.assertEqual(rrr, 10.0)
+
+    def test_prediction_inputs_boundaries(self):
+        # 0 overs completed (start of innings)
+        runs_left, balls_left, crr, rrr = calculate_prediction_inputs(180, 0, 0)
+        self.assertEqual(runs_left, 180)
+        self.assertEqual(balls_left, 120)
+        self.assertEqual(crr, 0.0)
+        self.assertEqual(rrr, 9.0)
+
+        # 20 overs completed (completed innings)
+        runs_left, balls_left, crr, rrr = calculate_prediction_inputs(180, 150, 20)
+        self.assertEqual(runs_left, 30)
+        self.assertEqual(balls_left, 0)
+        self.assertEqual(crr, 7.5)
+        self.assertEqual(rrr, 0.0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Fixes #176  incorrect balls_left calculation

#### Root Cause
The previous implementation derived `balls_left` using an overs/ball calculation that could produce incorrect values in edge cases near the end of an innings. This affected downstream metrics such as Required Run Rate (RRR) and win probability predictions.

#### Changes Made
- Reworked `balls_left` calculation using legal deliveries bowled.
- Added safeguards to prevent negative values.
- Updated dependent calculations where required.
- Added edge-case handling for completed innings and final-ball scenarios.

#### Result
`balls_left` now accurately reflects remaining deliveries and remains valid for all innings states, improving prediction reliability and feature consistency.