### PR TITLE
fix(predictor): add balls-in-over slider for per-ball granularity

### DIFF
--- a/application.py
+++ b/application.py
@@ -1526,9 +1526,11 @@ if st.session_state.page == "Analysis":
         st.markdown('<div class="input-label">Match State</div>', unsafe_allow_html=True)
         target = st.number_input("Target Score", min_value=50, max_value=300, value=180, step=1)
         score = st.number_input("Current Score", min_value=0, max_value=target - 1, value=50, step=1)
-        col_ov, col_wk = st.columns(2)
+        col_ov, col_ball, col_wk = st.columns(3)
         with col_ov:
             overs = st.slider("Overs Completed", min_value=0, max_value=20, value=10)
+        with col_ball:
+            balls_in_over = st.slider("Balls in Current Over", min_value=0, max_value=5, value=0, step=1)
         with col_wk:
             wickets = st.number_input("Wickets Fallen", min_value=0, max_value=9, value=2)
         st.markdown('</div>', unsafe_allow_html=True)
@@ -1615,7 +1617,11 @@ if st.session_state.page == "Analysis":
 
     # ---- PREDICTION OUTPUT ----
     if analyze:
-        runs_left, balls_left, crr, rrr = safe_calculate_rates(score, target, overs)
+        runs_left = target - score
+        total_balls_bowled = overs * 6 + balls_in_over
+        balls_left = max(120 - total_balls_bowled, 0)
+        crr = score / (total_balls_bowled / 6) if total_balls_bowled > 0 else 0.0
+        rrr = (runs_left * 6) / balls_left if balls_left > 0 else 0.0
 
         input_df = pd.DataFrame({
             'batting_team': [batting_team],


### PR DESCRIPTION
Fixes #155
Fixes #156

## Problem

The win-probability predictor tracked match progress only in whole overs, discarding up to 5 balls of precision for any delivery bowled mid-over. As a result:

- `balls_left` was always a multiple of 6, never reflecting the true number of balls remaining
- `crr` divided by integer overs, giving the wrong rate during an ongoing over
- `rrr` inherited the same inaccuracy

Additionally (issue #156), the overs slider had `max_value=19` in an earlier version; the calculation now uses `max(120 - total_balls_bowled, 0)` which correctly clamps the result even if the full 20 overs are entered.

## Fix

Added a **"Balls in Current Over"** slider (0-5) in the Match State panel and updated all three derived metrics:

```python
total_balls_bowled = overs * 6 + balls_in_over
balls_left = max(120 - total_balls_bowled, 0)
crr = score / (total_balls_bowled / 6) if total_balls_bowled > 0 else 0.0
rrr = (runs_left * 6) / balls_left if balls_left > 0 else 0.0
```

The slider sits between "Overs Completed" and "Wickets Fallen" in a three-column layout, keeping the input area compact.

## Testing

- Over 10, ball 3: `balls_left = 120 - 63 = 57` (was 60 before)
- Over 0, ball 0: `crr = 0.0` (zero-division guard still holds)
- Over 20, ball 0: `balls_left = 0`, model falls into the `balls_left <= 0` edge-case path

Could you please add the appropriate labels (`level:*`, `type:bug`, `gssoc'26`) when you get a chance? Thank you!