### PR TITLE
fix(predictor): add explicit same-team guard to prevent invalid analysis

### DIFF
--- a/application.py
+++ b/application.py
@@ -1074,6 +1074,11 @@ if st.session_state.page == "Analysis":
 
     st.markdown('<div style="height:28px;"></div>', unsafe_allow_html=True)
 
+    # ---- SAME-TEAM GUARD ----
+    if batting_team == bowling_team:
+        st.error("Batting team and bowling team cannot be the same. Please select two different teams.")
+        st.stop()
+
     # ---- TEAM VS DISPLAY ----
     t1 = team_data[batting_team]
     if bowling_team in team_data:


### PR DESCRIPTION
Fixes #159

## Problem

When the same team was selected for both batting and bowling, the model received nonsensical input. While the bowling-team selectbox filters out the currently selected batting team via `[t for t in teams if t != batting_team]`, there was no hard stop to prevent this state from being reached through other means (e.g., direct URL/state manipulation, rapid widget re-selection during rerender).

## Fix

Added a defensive guard immediately after both team inputs are collected, before any downstream computation or UI rendering:

```python
if batting_team == bowling_team:
    st.error("Batting team and bowling team cannot be the same. Please select two different teams.")
    st.stop()
```

`st.stop()` halts the script at that point, so the VS display, analysis button, and prediction output are never rendered or executed for an invalid state.

## Testing

- Normal operation (different teams): no change in behavior
- Same-team edge case: red error banner is shown and the rest of the page does not render
- The selectbox filter still prevents this from being reachable in normal UI flow; the guard is a safety net

Could you please add the appropriate labels (`level:*`, `type:bug`, `gssoc'26`) when you get a chance? Thank you!