### PR TITLE
fix(data): resolve FileNotFoundError from hardcoded relative CSV paths

### DIFF
--- a/application.py
+++ b/application.py
@@ -28,6 +28,7 @@ import os
 import joblib
 import logging
 import textwrap
+from pathlib import Path
 
 from sklearn.compose import ColumnTransformer
 from sklearn.preprocessing import OneHotEncoder
@@ -1021,8 +1022,9 @@ team_data = {
 # -----------------------------------
 @st.cache_data
 def load_data():
-    matches = pd.read_csv("matches.csv")
-    deliveries = pd.read_csv("deliveries.csv")
+    _base = Path(__file__).parent
+    matches = pd.read_csv(_base / "matches.csv")
+    deliveries = pd.read_csv(_base / "deliveries.csv")
     return matches, deliveries
 
 # -----------------------------------
@@ -1039,9 +1041,10 @@ def get_model(model_name='logistic'):
 
 @st.cache_resource
 def train_model(model_name='logistic'):
-    model_path = f"{model_name}_model.pkl"
+    _base = Path(__file__).parent
+    model_path = _base / f"{model_name}_model.pkl"
 
-    if os.path.exists(model_path):
+    if model_path.exists():
         try:
             return joblib.load(model_path)
         except Exception as e:

--- a/pages/stats.py
+++ b/pages/stats.py
@@ -1,6 +1,8 @@
 import pandas as pd
 import streamlit as st
 import plotly.graph_objects as go
+from pathlib import Path
+
 #  page config 
 st.set_page_config(
     page_title="CricScope · Stats",
@@ -210,8 +212,10 @@ hr {
 #  data loading 
 @st.cache_data
 def load_data():
-    matches = pd.read_csv("matches.csv")
-    deliveries = pd.read_csv("deliveries.csv")
+    # pages/ sits one level below the repo root where the CSVs live
+    _base = Path(__file__).parent.parent
+    matches = pd.read_csv(_base / "matches.csv")
+    deliveries = pd.read_csv(_base / "deliveries.csv")
     return matches, deliveries
 
 


### PR DESCRIPTION
Fixes #158

## Problem

Both `application.py` and `pages/stats.py` loaded their data with hardcoded relative paths:

```python
matches = pd.read_csv("matches.csv")
deliveries = pd.read_csv("deliveries.csv")
```

Relative paths are resolved from the process working directory, not from the script's location. When Streamlit is launched from any directory other than the repo root (e.g., `streamlit run /path/to/CricScope/application.py` from `~`), Python looks for `matches.csv` in `~` and raises:

```
FileNotFoundError: [Errno 2] No such file or directory: 'matches.csv'
```

## Fix

Used `pathlib.Path(__file__).parent` to build an absolute path anchored to each file's own directory:

**`application.py`**
```python
from pathlib import Path

_base = Path(__file__).parent
matches = pd.read_csv(_base / "matches.csv")
deliveries = pd.read_csv(_base / "deliveries.csv")
```

**`pages/stats.py`**
```python
from pathlib import Path

_base = Path(__file__).parent.parent  # pages/ -> repo root
matches = pd.read_csv(_base / "matches.csv")
deliveries = pd.read_csv(_base / "deliveries.csv")
```

This is the standard Python idiom for locating files relative to a script and works regardless of the CWD from which Streamlit is invoked.

## Testing

- Launch with `streamlit run application.py` from repo root: works as before
- Launch with `streamlit run /abs/path/CricScope/application.py` from any other directory: now loads data correctly instead of crashing

Could you please add the appropriate labels (`level:*`, `type:bug`, `gssoc'26`) when you get a chance? Thank you!