### PR TITLE
Add error boundary around predict_proba call in Analysis page

### DIFF
--- a/application.py
+++ b/application.py
@@ -1171,17 +1171,25 @@ if st.session_state.page == "Analysis":
             'rrr': [rrr]
         })
 
-        with st.spinner(""):
-            time.sleep(0.4)
-            # Edge-case handling for final ball/completed innings boundaries
-            if runs_left <= 0:
-                win = 1.0
-                lose = 0.0
-            elif balls_left <= 0:
-                win = 0.0
-                lose = 1.0
-            else:
-                proba = pipe.predict_proba(input_df)[0]
+        if runs_left <= 0:
+            win = 1.0
+            lose = 0.0
+        elif balls_left <= 0:
+            win = 0.0
+            lose = 1.0
+        else:
+            if pipe is None:
+                st.error("Model not loaded. Please restart the app.")
+                st.stop()
+            with st.spinner(""):
+                try:
+                    proba = pipe.predict_proba(input_df)[0]
+                except Exception as e:
+                    st.error(f"Prediction unavailable — model encountered an error: {e}")
+                    st.stop()
+                if np.isnan(proba).any():
+                    st.error("Model returned invalid probabilities. The training pipeline may have produced corrupted coefficients.")
+                    st.stop()
                 win = proba[1]
                 lose = proba[0]
 


### PR DESCRIPTION
Fixes #165

## What this fixes

The predict_proba() call in the Analysis page's prediction block had no error handling. NaN probabilities from corrupted training data rendered as "nan%" in the UI with no indication of failure. Exceptions from feature mismatch or a None pipeline (cache eviction) crashed the app with raw tracebacks exposed to the user. A 400ms time.sleep() added unnecessary latency to every prediction.

## Root cause

application.py:1184 had three unprotected failure modes:
- NaN coefficients from corrupted training data produce [NaN, NaN] from predict_proba(), which round(win * 100) silently renders as "nan%"
- ValueError from misaligned input features propagates as an unhandled exception, crashing the app
- If @st.cache_resource evicts the pipeline mid-session, pipe becomes None and predict_proba() throws AttributeError
- time.sleep(0.4) at line 1175 added 400ms of pure latency with no functional benefit

## What changed

- Removed time.sleep(0.4) — unnecessary UX theater
- Moved edge-case boundaries (runs_left <= 0, balls_left <= 0) outside the spinner block since they don't need model inference
- Added pipe is None guard before prediction
- Wrapped predict_proba() in try/except with a user-facing error message
- Added NaN validation on the returned probabilities with an explicit error

## How to verify

1. Run python -m pytest test_calculations.py -v — all 6 tests pass
2. Start the app with streamlit run application.py, navigate to Analysis, configure a match, and click Run Analysis — prediction displays normally
3. Verify no time.sleep delay is present (prediction should complete immediately after the spinner appears)

## Edge cases considered

- runs_left <= 0: Handled before any prediction call, returns 100% win
- balls_left <= 0: Handled before any prediction call, returns 0% win
- pipe is None: Shows error and stops, rather than crashing with AttributeError
- predict_proba() exception: Caught generically, shows error message with exception detail
- NaN probabilities: Detected after prediction, shows user-facing error instead of rendering "nan%"
