### PR TITLE
Fix non-deterministic training pipeline from chained assignment on filtered DataFrame view

### DIFF
--- a/application.py
+++ b/application.py
@@ -949,7 +949,7 @@ def train_model(model_name='logistic'):
     total_df.rename(columns={'total_runs': 'target'}, inplace=True)
 
     df = df.merge(total_df, on='match_id')
-    df = df[df['inning'] == 2]
+    df = df[df['inning'] == 2].copy()
 
     df['current_score'] = df.groupby('match_id')['total_runs'].cumsum()
     df['runs_left'] = df['target'] - df['current_score']
@@ -965,13 +965,16 @@ def train_model(model_name='logistic'):
     df['crr'] = np.where(overs_bowled > 0, df['current_score'] / overs_bowled, 0.0)
     df['rrr'] = np.where(df['balls_left'] > 0, (df['runs_left'] * 6) / df['balls_left'], 0.0)
 
-    df.replace([np.inf, -np.inf], np.nan, inplace=True)
+    df = df.replace([np.inf, -np.inf], np.nan)
     df['result'] = np.where(df['batting_team'] == df['winner'], 1, 0)
 
     final_df = df[['batting_team', 'bowling_team', 'city',
                    'runs_left', 'balls_left', 'wickets',
                    'target', 'crr', 'rrr', 'result']]
     final_df.dropna(inplace=True)
+
+    assert not final_df.isin([np.inf, -np.inf]).any().any(), \
+        "inf values remain in training data after replace"
 
     X = final_df.drop('result', axis=1)
     y = final_df['result']
@@ -1024,7 +1027,7 @@ def evaluate_model(model_name='logistic'):
     total_df.rename(columns={'total_runs': 'target'}, inplace=True)
 
     df = df.merge(total_df, on='match_id')
-    df = df[df['inning'] == 2]
+    df = df[df['inning'] == 2].copy()
 
     df['current_score'] = df.groupby('match_id')['total_runs'].cumsum()
     df['runs_left'] = df['target'] - df['current_score']
@@ -1040,13 +1043,16 @@ def evaluate_model(model_name='logistic'):
     df['crr'] = np.where(overs_bowled > 0, df['current_score'] / overs_bowled, 0.0)
     df['rrr'] = np.where(df['balls_left'] > 0, (df['runs_left'] * 6) / df['balls_left'], 0.0)
 
-    df.replace([np.inf, -np.inf], np.nan, inplace=True)
+    df = df.replace([np.inf, -np.inf], np.nan)
     df['result'] = np.where(df['batting_team'] == df['winner'], 1, 0)
 
     final_df = df[['batting_team', 'bowling_team', 'city',
                    'runs_left', 'balls_left', 'wickets',
                    'target', 'crr', 'rrr', 'result']]
     final_df.dropna(inplace=True)
+
+    assert not final_df.isin([np.inf, -np.inf]).any().any(), \
+        "inf values remain in evaluation data after replace"
 
     X = final_df.drop('result', axis=1)
     y = final_df['result']
@@ -1678,6 +1684,9 @@ if st.session_state.page == "Analysis":
                 pass # Bypasses ML model prediction cleanly
             else:
                 proba = pipe.predict_proba(input_df)[0]
+                if np.isnan(proba).any():
+                    st.error("Model returned invalid probabilities. The training data contains corrupted values. Please restart the application.")
+                    st.stop()
                 win = proba[1]
                 lose = proba[0]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 streamlit
 scikit-learn
 numpy
-pandas
+pandas>=2.0,<3.0
 matplotlib
 joblib
 seaborn


### PR DESCRIPTION
## What this fixes

`train_model()` and `evaluate_model()` in `application.py` both apply `df[df["inning"] == 2]` without `.copy()`, then perform 10+ column mutation operations (groupby cumsum, np.where, inplace replace) on the resulting object. On pandas >= 2.2, the boolean-indexed result may be a view or a copy depending on internal memory layout — the mutations can silently target a transient copy, leaving the intended DataFrame unmodified. When `df.replace(..., inplace=True)` silently fails, `inf` values from the RRR calculation propagate through `dropna()` (which only removes NaN, not inf) into `LogisticRegression.fit()`, producing NaN model coefficients and garbage predictions.

## Root cause

Two root causes:

1. **Missing `.copy()` at `application.py:952` and `application.py:1027`** — `df = df[df["inning"] == 2]` returns an ambiguous view/copy. All subsequent column assignments (`df["x"] = ...`) are chained assignments that may write to a temporary copy and get discarded.

2. **`inplace=True` at `application.py:968` and `application.py:1043`** — `df.replace([np.inf, -np.inf], np.nan, inplace=True)` operates on whatever `df` is at that point. If `df` is already a copy (because earlier mutations were discarded), this silently no-ops and `inf` values remain.

## What changed

- `application.py:952` — Added `.copy()` after the boolean index in `train_model()`
- `application.py:968` — Replaced `df.replace(inplace=True)` with `df = df.replace()` in `train_model()`
- `application.py:976-977` — Added `assert not final_df.isin([np.inf, -np.inf]).any().any()` in `train_model()`
- `application.py:1027` — Added `.copy()` after the boolean index in `evaluate_model()`
- `application.py:1043` — Replaced `df.replace(inplace=True)` with `df = df.replace()` in `evaluate_model()`
- `application.py:1054-1055` — Added `assert not final_df.isin([np.inf, -np.inf]).any().any()` in `evaluate_model()`
- `application.py:1687-1689` — Added NaN detection on `predict_proba()` output with user-facing error
- `requirements.txt` — Pinned `pandas>=2.0,<3.0`

## How to verify

1. Check out the branch and install dependencies
2. Run `pip install pandas==1.5.3` to reproduce the old version — observe that `SettingWithCopyWarning` no longer appears
3. Run `pip install pandas==2.2` to verify the fix works on the latest pandas
4. Run `streamlit run application.py` — the app should start and produce predictions without errors
5. Run `python -m pytest test_calculations.py -v` — all 6 existing tests must pass

## Edge cases considered

- **pandas 3.0 compatibility**: The `inplace=True` removal ensures the app wont crash when pandas removes the parameter entirely
- **Silent data corruption**: The assert after `dropna()` catches any residual `inf` values at training time instead of letting them silently produce NaN coefficients
- **User-facing NaN**: The `predict_proba()` guard catches corrupted model output and shows an error instead of displaying NaN as a valid probability
- **Version pin boundary**: `>=2.0` allows pandas 2.x feature set; `<3.0` prevents breakage from the planned `inplace` removal

Closes #163