### PR TITLE
Add error boundary around predict_proba calls across all prediction sites

### DIFF
--- a/application.py
+++ b/application.py
@@ -1129,9 +1129,14 @@ def generate_ball_by_ball_df(pipe, batting_team, bowling_team, selected_city, ta
             win = 0.0
             lose = 1.0
         else:
-            proba = pipe.predict_proba(input_df)[0]
-            win = proba[1]
-            lose = proba[0]
+            try:
+                proba = pipe.predict_proba(input_df)[0]
+                if np.isnan(proba).any():
+                    win, lose = 0.5, 0.5
+                else:
+                    win, lose = proba[1], proba[0]
+            except Exception:
+                win, lose = 0.5, 0.5
             
         records.append({
             'over': curr_over,
@@ -1661,11 +1666,21 @@ if st.session_state.page == "Analysis":
                 lose = 1.0
 
         with st.spinner(""):
-            time.sleep(0.4)
             if is_match_decided:
-                pass # Bypasses ML model prediction cleanly
+                pass
             else:
-                proba = pipe.predict_proba(input_df)[0]
+                if pipe is None:
+                    st.error("Model not loaded. Please restart the app.")
+                    st.stop()
+                try:
+                    proba = pipe.predict_proba(input_df)[0]
+                except Exception as e:
+                    logging.error(f"Prediction failed: {e}")
+                    st.error("Prediction unavailable — model encountered an error. Adjust inputs and try again.")
+                    st.stop()
+                if np.isnan(proba).any():
+                    st.error("Model returned invalid probabilities. The training pipeline may have produced corrupted coefficients. Restart the app to retrain.")
+                    st.stop()
                 win = proba[1]
                 lose = proba[0]
 
@@ -1820,12 +1835,17 @@ if st.session_state.page == "Analysis":
                     'rrr': [c_rrr]
                 })
 
-                proj_proba = pipe.predict_proba(proj_df)[0]
+                try:
+                    proj_proba = pipe.predict_proba(proj_df)[0]
+                    bat_prob = round(proj_proba[1] * 100, 2)
+                    bowl_prob = round(proj_proba[0] * 100, 2)
+                except Exception:
+                    bat_prob, bowl_prob = 50.0, 50.0
                 rows.append({
                     "over": ov + 1,
                     "ball": bl,
-                    "batting_team_prob": round(proj_proba[1] * 100, 2),
-                    "bowling_team_prob": round(proj_proba[0] * 100, 2)
+                    "batting_team_prob": bat_prob,
+                    "bowling_team_prob": bowl_prob
                 })
 
         export_df = pd.DataFrame(rows)

--- a/pages/live_match.py
+++ b/pages/live_match.py
@@ -573,6 +573,8 @@ def compute_prediction(batting_team, bowling_team, venue, target,
         })
 
         proba = pipe.predict_proba(input_df)[0]
+        if np.isnan(proba).any():
+            return None
 
         return {
             "batting_win": round(proba[1] * 100),


### PR DESCRIPTION
## What this fixes

Four `predict_proba()` call sites across `application.py` and `pages/live_match.py` had no error handling. If the model produced NaN probabilities (from corrupted training coefficients), the UI rendered `nan%` as a valid-looking percentage. If `predict_proba` threw an exception (from feature mismatch, pipeline corruption, or cache eviction), the app crashed with a raw Streamlit traceback exposed to the user. The Analysis page also had a `time.sleep(0.4)` that added 400ms of unnecessary latency to every prediction.

## Root cause

Every `predict_proba()` call in the codebase assumed the model pipeline would always return valid probabilities. Three failure modes existed with no guard:

1. NaN coefficients from corrupted training data (see issue #163) — `predict_proba` returns `[NaN, NaN]`, `round(NaN * 100)` renders as `nan%` in the UI
2. Feature mismatch between training and inference — `predict_proba` throws `ValueError`, no try/except exists, the exception propagates to Streamlits handler and displays a raw traceback
3. Pipeline state corruption or `None` pipe — `AttributeError` crashes the app with no recovery path

Additionally, `time.sleep(0.4)` at the Analysis page prediction call added unnecessary latency with no functional purpose.

## What changed

- `application.py:1664` — Removed `time.sleep(0.4)` from the Analysis page prediction path
- `application.py:1669-1685` — Added `pipe is None` guard, try/except around `predict_proba`, and NaN validation with user-facing `st.error()` and `st.stop()` in the Analysis page
- `application.py:1132-1140` — Added try/except and NaN fallback in `generate_ball_by_ball_df()` for CSV export data
- `application.py:1838-1847` — Added try/except fallback in the ball-by-ball projection loop for CSV export
- `pages/live_match.py:576-577` — Added NaN check in `compute_prediction()` to return `None` instead of invalid probabilities, which the caller already handles gracefully

## How to verify

1. Run `streamlit run application.py`, open the Analysis page, select any teams/match state, and click "Run Analysis" — the app should produce predictions without the previous 400ms delay
2. To test the NaN guard, temporarily modify `train_model()` to skip the `df.replace([np.inf, -np.inf], np.nan)` line, restart the app, and run a prediction — the error message "Model returned invalid probabilities..." should appear instead of `nan%`
3. Open the Model Performance page and confirm it still loads and displays metrics correctly
4. Run `python -m pytest test_calculations.py -v` — all 6 existing tests must pass

## Edge cases considered

- **NaN from corrupted training**: Caught by `np.isnan(proba).any()` check — shows error message instead of `nan%`
- **Exception from feature mismatch**: Caught by try/except — shows "Prediction unavailable" error instead of traceback
- **pipe is None**: Explicit guard with user-facing error
- **CSV export resilience**: The ball-by-ball generator and projection loop fall back to 50/50 probabilities on failure so the download button still produces usable data
- **Live match tracker**: Returns `None` on NaN, which the caller already handles by showing "N/A" instead of crashing

Closes #165