### PR TITLE
docs: formalize security policy and response SLA in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,50 +1,49 @@
-# 🔐 Security Policy
+# Security Policy
+
+We take the security of CricScope seriously. If you believe you have found a security vulnerability in this project, we appreciate your help in disclosing it to us in a responsible manner.
 
 ## Supported Versions
 
-The `main` branch is actively maintained with security updates and bug fixes.
+Currently, security updates and patches are actively backported to the following branches:
 
-If you are using an older version or a personal fork, we strongly recommend syncing regularly with the latest upstream repository updates.
+| Version | Status |
+|:---|:---|
+| Main (1.x) | Supported |
+| < 1.0.0 | Unsupported |
 
----
+We strongly recommend that all users run the latest release of CricScope. If you are running an older release or an un-synced fork, please sync with the upstream repository to receive active patches.
 
-# 🚨 Reporting a Vulnerability
+## Reporting a Vulnerability
 
-We take security issues seriously and appreciate responsible disclosure from the community.
+Please do **NOT** report security vulnerabilities publicly via GitHub Issues, Pull Requests, or public comments. Instead, report them privately using the procedure below.
 
-Please do NOT report security vulnerabilities publicly through GitHub Issues.
+### How to Report
 
----
+To report a suspected security vulnerability:
 
-# 📩 How to Report
+1.  Send a private email to the project maintainer at **itsarnav.singh80@gmail.com**.
+2.  Provide a clear and descriptive subject line (e.g., `Security Vulnerability Report: [Brief Description]`).
+3.  Include as much detail as possible in your report to help us understand and resolve the issue quickly:
+    *   **Description:** A detailed explanation of the vulnerability and its potential impact.
+    *   **Steps to Reproduce:** Clear, step-by-step instructions or a minimal proof-of-concept (PoC) script.
+    *   **Affected Components:** Specific files, routes, or functions involved (e.g., API key inputs or data loaders).
+    *   **Mitigation Suggestions:** Any ideas you have on how to resolve the vulnerability.
 
-If you discover a vulnerability:
+## Response and Resolution Timeline
 
-1. Report the issue privately to the project maintainer
-2. Include detailed reproduction steps
-3. Explain the potential impact
-4. Include screenshots or proof-of-concept if applicable
+Once a report is received, the CricScope maintainers commit to the following response timeline:
 
----
+1.  **Initial Acknowledgment:** Within 48 hours of receiving the email.
+2.  **Investigation and Triage:** Within 5 business days, we will verify the vulnerability and determine its severity level (Low, Medium, High, or Critical).
+3.  **Remediation:** We aim to implement, test, and deploy a security fix within 30 days of triage.
+4.  **Coordinated Disclosure:** We will coordinate with the reporter to publish a security advisory alongside a patched release, ensuring credit is properly attributed.
 
-# ⏱ Response Timeline
+## Out of Scope
 
-- Initial acknowledgment within 48 hours
-- Verification and investigation process
-- Security fix implementation
-- Responsible disclosure coordination
-- Resolution notification after patch deployment
+The following areas are considered out of scope for security reports:
 
----
+*   Standard limitations or issues related to Streamlit's underlying architecture (e.g., local execution vulnerabilities if the host server is already compromised).
+*   Known, publicly documented behaviors of scikit-learn model storage (pickle format serialization limits).
+*   Denial of Service (DoS) attacks or automated brute-forcing of local deployment ports.
 
-# 🤝 Responsible Disclosure
-
-Please avoid publicly sharing vulnerabilities until a fix has been released.
-
-Responsible disclosure helps keep the project and community secure.
-
----
-
-# ❤️ Thank You
-
-Thank you for helping improve the security and reliability of CricScope.
+Thank you for helping us keep the CricScope project and its community safe!


### PR DESCRIPTION
Closes #259 

## Description
This Pull Request overhauls `SECURITY.md` to implement a highly detailed and professional vulnerability disclosure policy, eliminating raw emojis and providing a clean support layout.

### Key Changes:
- Standardized the active release support matrix table.
- Formalized private disclosure contact reporting guidelines via email.
- Provided a clear SLA response timeline (48hr acknowledgment, 5-day triage, 30-day resolution).
- Outlined out-of-scope security elements for the deployment setup.

### Verification:
- Checked markdown formatting and table rendering.
