### PR TITLE
docs: upgrade to Contributor Covenant v2.1 code of conduct standard

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,78 +1,67 @@
 # Contributor Covenant Code of Conduct
 
-## 🌟 Our Commitment
+## Our Pledge
 
-We as contributors and maintainers pledge to make participation in the CricScope project a respectful, inclusive, and harassment-free experience for everyone.
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
 
-We are committed to fostering an open and welcoming environment regardless of:
-- Age
-- Body size
-- Disability
-- Ethnicity
-- Gender identity and expression
-- Experience level
-- Nationality
-- Personal appearance
-- Race
-- Religion
-- Sexual identity and orientation
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
 
----
+## Our Standards
 
-# 🤝 Expected Behavior
+Examples of behavior that contributes to a positive environment for our community include:
 
-Examples of positive behavior include:
-
-- Being respectful and constructive
-- Welcoming new contributors
-- Accepting feedback gracefully
-- Showing empathy toward others
-- Collaborating professionally
-- Focusing on what is best for the community
-
----
-
-# 🚫 Unacceptable Behavior
+*   Demonstrating empathy and kindness toward other people
+*   Being respectful of differing opinions, viewpoints, and experiences
+*   Giving and gracefully accepting constructive feedback
+*   Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+*   Focusing on what is best for the overall community
 
 Examples of unacceptable behavior include:
 
-- Harassment or discrimination
-- Trolling or insulting comments
-- Personal or political attacks
-- Public or private harassment
-- Publishing others' private information
-- Any conduct inappropriate in a professional environment
+*   The use of sexualized language or imagery, and unwelcome sexual attention or advances
+*   Trolling, insulting or derogatory comments, and personal or political attacks
+*   Public or private harassment
+*   Publishing others' private information, such as a physical or email address, without their explicit permission
+*   Other conduct which could reasonably be considered inappropriate in a professional setting
 
----
+## Enforcement Responsibilities
 
-# ⚖️ Enforcement Responsibilities
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate, fair, and corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
 
-Project maintainers are responsible for clarifying and enforcing community standards.
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, questions, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
 
-Maintainers may remove, edit, or reject comments, commits, issues, or pull requests that violate this Code of Conduct.
+## Scope
 
----
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
 
-# 📢 Reporting Issues
+## Enforcement
 
-If you experience or witness unacceptable behavior, please report it privately to the project maintainers.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders at **itsarnav.singh80@gmail.com**. All complaints will be reviewed and investigated promptly and fairly.
 
-All complaints will be reviewed and investigated promptly and fairly.
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 
----
+## Enforcement Guidelines
 
-# ❤️ Community Standards
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
 
-CricScope values:
-- Respectful collaboration
-- Beginner-friendly contributions
-- Constructive discussions
-- Inclusive open-source participation
+### 1. Correction
+**Community Impact:** Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+**Consequence:** A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
 
-Together, we can build a healthy and welcoming open-source community.
+### 2. Warning
+**Community Impact:** A violation through a single incident or series of actions.
+**Consequence:** A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
 
----
+### 3. Temporary Ban
+**Community Impact:** A serious violation of community standards, including sustained harassing behavior.
+**Consequence:** A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
 
-# 📜 Attribution
+### 4. Permanent Ban
+**Community Impact:** Demonstrating a pattern of violation of community standards, including sustained harassing behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+**Consequence:** A permanent ban from any sort of public interaction within the community.
 
-This Code of Conduct is adapted from the Contributor Covenant Code of Conduct.
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).


### PR DESCRIPTION
Closes #261 

## Description
This Pull Request upgrades `CODE_OF_CONDUCT.md` to the standard Contributor Covenant v2.1 specifications, providing explicit harassment definitions, community commitment declarations, and structured moderation timelines.

### Key Changes:
- Modernized the CoC file to Covenant v2.1 guidelines.
- Incorporated explicit Enforcement Guidelines detailing correction, warning, temporary, and permanent ban parameters.
- Setup professional, confidential maintainer contact reporting guidelines.

### Verification:
- Validated markdown formatting and hyperlink anchors.
