### PR TITLE
feat: Added filter reset mechanism to sidebar layout

### DIFF
--- a/application.py
+++ b/application.py
@@ -1164,6 +1164,28 @@ with st.sidebar:
             <span class="sidebar-tagline">Match Intelligence Platform</span>
         </div>
     """, unsafe_allow_html=True)
+    # -------------------------------------------------------------
+    # 1. RESET FILTERS BUTTON CODE (Directly Paste Here)
+    # -------------------------------------------------------------
+    # Yeh button pure sidebar ke dropdowns ki memory clear kar dega
+   # -------------------------------------------------------------
+    # FIXED RESET FILTERS BUTTON CODE
+    # -------------------------------------------------------------
+    if st.button("🔄 Reset All Filters", use_container_width=True):
+        # 1. Jo page abhi open hai (e.g., 'Analysis', 'Performance'), use variable me save kar lo
+        current_page = st.session_state.get("page", "Dashboard")
+        
+        # 2. Saari filter selections ko clear karo
+        st.session_state.clear()
+        
+        # 3. Clear karne ke baad, active page ko wapas memory me dal do taaki page change na ho
+        st.session_state["page"] = current_page
+        
+        # 4. Instant refresh
+        st.rerun()
+
+    st.markdown('<div class="sidebar-divider"></div>', unsafe_allow_html=True)
+    # -------------------------------------------------------------
     
 
     st.markdown('<div class="sidebar-section-label">Navigation</div>', unsafe_allow_html=True)


### PR DESCRIPTION
### 📝 Description
Introduced a "Reset All Filters" action button inside the primary sidebar layout. It leverages `st.session_state` resetting coupled with page state backup tracking to cleanly wipe analytical filter options across components without dumping active workspace layout states or routing context. 

### 🔗 Related Issues
Closes #228 

### 🛠️ Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] UI/UX Optimization

##Screenshots
<img width="1919" height="884" alt="image" src="https://github.com/user-attachments/assets/032b1546-de8c-4699-9f1e-1e7b50f957fe" />


### ✅ Testing Checklist
- [x] Verified sidebar widgets accurately roll back to system defaults.
- [x] Confirmed existing dashboard view states remain uninterrupted upon execution.
- [x] Successfully tested end-to-end flow locally on Python 3.