### PR TITLE
 feat: add model reliability backtesting dashboard

### DIFF
--- a/model_evaluation.py
+++ b/model_evaluation.py
@@ -1,0 +1,391 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from sklearn.compose import ColumnTransformer
+from sklearn.linear_model import LogisticRegression
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import OneHotEncoder
+
+
+CAT_FEATURES = ["batting_team", "bowling_team", "city"]
+NUM_FEATURES = ["runs_left", "balls_left", "wickets", "target", "crr", "rrr"]
+FEATURE_COLUMNS = CAT_FEATURES + NUM_FEATURES
+
+
+def calculate_brier_score(y_true, y_prob) -> float:
+    y_true_arr = np.asarray(y_true, dtype=float)
+    y_prob_arr = np.asarray(y_prob, dtype=float)
+
+    if len(y_true_arr) == 0:
+        return float("nan")
+
+    return float(np.mean((y_prob_arr - y_true_arr) ** 2))
+
+
+def classify_phase_from_balls_left(balls_left: float) -> str:
+    overs_completed = (120 - balls_left) / 6
+
+    if overs_completed <= 6:
+        return "Powerplay"
+
+    if overs_completed <= 15:
+        return "Middle Overs"
+
+    return "Death Overs"
+
+
+def is_pressure_situation(row: pd.Series) -> bool:
+    return (
+        row["rrr"] > 10
+        and row["balls_left"] < 30
+        and row["wickets"] <= 4
+        and row["runs_left"] > 40
+    )
+
+
+def prepare_match_state_data(matches: pd.DataFrame, deliveries: pd.DataFrame) -> pd.DataFrame:
+    matches_df = matches.copy()
+    deliveries_df = deliveries.copy()
+
+    required_delivery_columns = {
+        "match_id",
+        "inning",
+        "batting_team",
+        "bowling_team",
+        "over",
+        "ball",
+        "total_runs",
+        "player_dismissed",
+    }
+
+    missing_columns = required_delivery_columns - set(deliveries_df.columns)
+    if missing_columns:
+        raise ValueError(f"Missing delivery columns: {sorted(missing_columns)}")
+
+    if "id" not in matches_df.columns:
+        raise ValueError("matches.csv must contain an 'id' column")
+
+    if "winner" not in matches_df.columns:
+        raise ValueError("matches.csv must contain a 'winner' column")
+
+    if "city" not in matches_df.columns:
+        matches_df["city"] = matches_df.get("venue", "Unknown")
+
+    if "season" not in matches_df.columns:
+        matches_df["season"] = "Unknown"
+
+    match_columns = ["id", "winner", "city", "season"]
+
+    merged = deliveries_df.merge(
+        matches_df[match_columns],
+        left_on="match_id",
+        right_on="id",
+        how="left",
+    )
+
+    first_innings_totals = (
+        merged[merged["inning"] == 1]
+        .groupby("match_id")["total_runs"]
+        .sum()
+        .reset_index()
+        .rename(columns={"total_runs": "target"})
+    )
+
+    first_innings_totals["target"] = first_innings_totals["target"] + 1
+
+    chase_df = merged.merge(first_innings_totals, on="match_id", how="inner")
+    chase_df = chase_df[chase_df["inning"] == 2].copy()
+
+    chase_df["current_score"] = chase_df.groupby("match_id")["total_runs"].cumsum()
+    chase_df["runs_left"] = chase_df["target"] - chase_df["current_score"]
+
+    balls_bowled = ((chase_df["over"] - 1) * 6) + chase_df["ball"]
+    chase_df["balls_left"] = (120 - balls_bowled).clip(lower=0)
+
+    chase_df["player_dismissed"] = chase_df["player_dismissed"].notna().astype(int)
+    wickets_lost = chase_df.groupby("match_id")["player_dismissed"].cumsum()
+    chase_df["wickets"] = 10 - wickets_lost
+
+    overs_bowled = (chase_df["over"] - 1) + (chase_df["ball"] / 6)
+    chase_df["crr"] = np.where(
+        overs_bowled > 0,
+        chase_df["current_score"] / overs_bowled,
+        0.0,
+    )
+
+    chase_df["rrr"] = np.where(
+        chase_df["balls_left"] > 0,
+        (chase_df["runs_left"] * 6) / chase_df["balls_left"],
+        0.0,
+    )
+
+    chase_df.replace([np.inf, -np.inf], np.nan, inplace=True)
+
+    chase_df["result"] = np.where(chase_df["batting_team"] == chase_df["winner"], 1, 0)
+    chase_df["phase"] = chase_df["balls_left"].apply(classify_phase_from_balls_left)
+    chase_df["pressure_situation"] = chase_df.apply(is_pressure_situation, axis=1)
+
+    final_columns = [
+        "match_id",
+        "season",
+        "batting_team",
+        "bowling_team",
+        "city",
+        "runs_left",
+        "balls_left",
+        "wickets",
+        "target",
+        "crr",
+        "rrr",
+        "phase",
+        "pressure_situation",
+        "result",
+    ]
+
+    final_df = chase_df[final_columns].dropna().copy()
+    final_df = final_df[final_df["balls_left"] >= 0]
+    final_df = final_df[final_df["wickets"] >= 0]
+
+    return final_df
+
+
+def build_prediction_pipeline() -> Pipeline:
+    preprocessor = ColumnTransformer(
+        [
+            (
+                "cat",
+                OneHotEncoder(handle_unknown="ignore"),
+                CAT_FEATURES,
+            ),
+            (
+                "num",
+                "passthrough",
+                NUM_FEATURES,
+            ),
+        ]
+    )
+
+    return Pipeline(
+        [
+            ("preprocessor", preprocessor),
+            ("model", LogisticRegression(max_iter=1000)),
+        ]
+    )
+
+
+def run_historical_backtest(match_states: pd.DataFrame) -> pd.DataFrame:
+    if match_states.empty:
+        return pd.DataFrame()
+
+    df = match_states.copy()
+    df = df.sort_values(["season", "match_id"]).reset_index(drop=True)
+
+    seasons = list(pd.Series(df["season"].unique()).dropna())
+
+    backtest_frames = []
+
+    if len(seasons) < 2:
+        split_index = int(len(df) * 0.75)
+        train_df = df.iloc[:split_index]
+        test_df = df.iloc[split_index:]
+
+        if train_df.empty or test_df.empty:
+            return pd.DataFrame()
+
+        if train_df["result"].nunique() < 2:
+            return pd.DataFrame()
+
+        pipeline = build_prediction_pipeline()
+        pipeline.fit(train_df[FEATURE_COLUMNS], train_df["result"])
+
+        evaluated = test_df.copy()
+        evaluated["win_probability"] = pipeline.predict_proba(test_df[FEATURE_COLUMNS])[:, 1]
+        evaluated["predicted_result"] = (evaluated["win_probability"] >= 0.5).astype(int)
+        evaluated["correct_prediction"] = (
+            evaluated["predicted_result"] == evaluated["result"]
+        ).astype(int)
+
+        return evaluated
+
+    for season in seasons[1:]:
+        train_df = df[df["season"] < season]
+        test_df = df[df["season"] == season]
+
+        if train_df.empty or test_df.empty:
+            continue
+
+        if train_df["result"].nunique() < 2:
+            continue
+
+        pipeline = build_prediction_pipeline()
+        pipeline.fit(train_df[FEATURE_COLUMNS], train_df["result"])
+
+        evaluated = test_df.copy()
+        evaluated["win_probability"] = pipeline.predict_proba(test_df[FEATURE_COLUMNS])[:, 1]
+        evaluated["predicted_result"] = (evaluated["win_probability"] >= 0.5).astype(int)
+        evaluated["correct_prediction"] = (
+            evaluated["predicted_result"] == evaluated["result"]
+        ).astype(int)
+
+        backtest_frames.append(evaluated)
+
+    if not backtest_frames:
+        return pd.DataFrame()
+
+    return pd.concat(backtest_frames, ignore_index=True)
+
+
+def calculate_model_summary(predictions: pd.DataFrame) -> dict:
+    if predictions.empty:
+        return {
+            "samples": 0,
+            "accuracy": float("nan"),
+            "brier_score": float("nan"),
+            "average_predicted_probability": float("nan"),
+            "actual_win_rate": float("nan"),
+            "average_confidence": float("nan"),
+        }
+
+    confidence = np.maximum(
+        predictions["win_probability"],
+        1 - predictions["win_probability"],
+    )
+
+    return {
+        "samples": int(len(predictions)),
+        "accuracy": float(predictions["correct_prediction"].mean()),
+        "brier_score": calculate_brier_score(
+            predictions["result"],
+            predictions["win_probability"],
+        ),
+        "average_predicted_probability": float(predictions["win_probability"].mean()),
+        "actual_win_rate": float(predictions["result"].mean()),
+        "average_confidence": float(confidence.mean()),
+    }
+
+
+def create_probability_buckets(
+    predictions: pd.DataFrame,
+    n_bins: int = 10,
+) -> pd.DataFrame:
+    if predictions.empty:
+        return pd.DataFrame(
+            columns=[
+                "prediction_bucket",
+                "sample_count",
+                "average_predicted_probability",
+                "actual_win_rate",
+                "calibration_gap",
+            ]
+        )
+
+    df = predictions.copy()
+
+    bins = np.linspace(0, 1, n_bins + 1)
+    labels = [f"{int(bins[i] * 100)}-{int(bins[i + 1] * 100)}%" for i in range(n_bins)]
+
+    df["prediction_bucket"] = pd.cut(
+        df["win_probability"],
+        bins=bins,
+        labels=labels,
+        include_lowest=True,
+    )
+
+    grouped = (
+        df.groupby("prediction_bucket", observed=False)
+        .agg(
+            sample_count=("result", "size"),
+            average_predicted_probability=("win_probability", "mean"),
+            actual_win_rate=("result", "mean"),
+        )
+        .reset_index()
+    )
+
+    grouped["calibration_gap"] = (
+        grouped["actual_win_rate"] - grouped["average_predicted_probability"]
+    )
+
+    return grouped
+
+
+def calculate_season_wise_metrics(predictions: pd.DataFrame) -> pd.DataFrame:
+    return _group_metrics(predictions, "season")
+
+
+def calculate_phase_wise_metrics(predictions: pd.DataFrame) -> pd.DataFrame:
+    return _group_metrics(predictions, "phase")
+
+
+def calculate_pressure_situation_metrics(predictions: pd.DataFrame) -> pd.DataFrame:
+    if predictions.empty:
+        return pd.DataFrame()
+
+    pressure_df = predictions[predictions["pressure_situation"]].copy()
+
+    if pressure_df.empty:
+        return pd.DataFrame(
+            [
+                {
+                    "situation": "Pressure Chase",
+                    "samples": 0,
+                    "accuracy": float("nan"),
+                    "brier_score": float("nan"),
+                    "average_predicted_probability": float("nan"),
+                    "actual_win_rate": float("nan"),
+                    "calibration_gap": float("nan"),
+                }
+            ]
+        )
+
+    return pd.DataFrame(
+        [
+            {
+                "situation": "Pressure Chase",
+                "samples": int(len(pressure_df)),
+                "accuracy": float(pressure_df["correct_prediction"].mean()),
+                "brier_score": calculate_brier_score(
+                    pressure_df["result"],
+                    pressure_df["win_probability"],
+                ),
+                "average_predicted_probability": float(
+                    pressure_df["win_probability"].mean()
+                ),
+                "actual_win_rate": float(pressure_df["result"].mean()),
+                "calibration_gap": float(
+                    pressure_df["result"].mean()
+                    - pressure_df["win_probability"].mean()
+                ),
+            }
+        ]
+    )
+
+
+def _group_metrics(predictions: pd.DataFrame, group_column: str) -> pd.DataFrame:
+    if predictions.empty or group_column not in predictions.columns:
+        return pd.DataFrame()
+
+    rows = []
+
+    for group_value, group_df in predictions.groupby(group_column):
+        rows.append(
+            {
+                group_column: group_value,
+                "samples": int(len(group_df)),
+                "accuracy": float(group_df["correct_prediction"].mean()),
+                "brier_score": calculate_brier_score(
+                    group_df["result"],
+                    group_df["win_probability"],
+                ),
+                "average_predicted_probability": float(
+                    group_df["win_probability"].mean()
+                ),
+                "actual_win_rate": float(group_df["result"].mean()),
+                "calibration_gap": float(
+                    group_df["result"].mean()
+                    - group_df["win_probability"].mean()
+                ),
+            }
+        )
+
+    return pd.DataFrame(rows)

--- a/pages/Model_Reliability_Backtesting.py
+++ b/pages/Model_Reliability_Backtesting.py
@@ -1,0 +1,349 @@
+import plotly.express as px
+import plotly.graph_objects as go
+import streamlit as st
+import pandas as pd
+
+from model_evaluation import (
+    calculate_model_summary,
+    calculate_phase_wise_metrics,
+    calculate_pressure_situation_metrics,
+    calculate_season_wise_metrics,
+    create_probability_buckets,
+    prepare_match_state_data,
+    run_historical_backtest,
+)
+
+
+st.set_page_config(
+    page_title="Model Reliability & Backtesting",
+    layout="wide",
+)
+
+st.markdown(
+    """
+    <style>
+    .metric-card {
+        background: linear-gradient(135deg, rgba(15, 23, 42, 0.96), rgba(30, 41, 59, 0.88));
+        border: 1px solid rgba(250, 204, 21, 0.25);
+        border-radius: 18px;
+        padding: 1.2rem;
+        box-shadow: 0 12px 35px rgba(0, 0, 0, 0.28);
+    }
+
+    .metric-label {
+        color: #cbd5e1;
+        font-size: 0.8rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+    }
+
+    .metric-value {
+        color: #facc15;
+        font-size: 2rem;
+        font-weight: 800;
+        margin-top: 0.35rem;
+    }
+
+    .section-title {
+        color: #f8fafc;
+        font-size: 1.55rem;
+        font-weight: 800;
+        margin-top: 1.5rem;
+        margin-bottom: 0.75rem;
+    }
+
+    .subtle-text {
+        color: #94a3b8;
+        font-size: 0.95rem;
+    }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
+
+@st.cache_data(show_spinner=False)
+def load_datasets():
+    matches = pd.read_csv("matches.csv")
+    deliveries = pd.read_csv("deliveries.csv")
+    return matches, deliveries
+
+
+@st.cache_data(show_spinner=False)
+def build_backtest(sample_size: int):
+    matches, deliveries = load_datasets()
+    match_states = prepare_match_state_data(matches, deliveries)
+
+    if sample_size and len(match_states) > sample_size:
+        match_states = (
+            match_states.sample(sample_size, random_state=42)
+            .sort_values(["season", "match_id"])
+            .reset_index(drop=True)
+        )
+
+    predictions = run_historical_backtest(match_states)
+    return match_states, predictions
+
+
+def format_percent(value):
+    if pd.isna(value):
+        return "N/A"
+
+    return f"{value * 100:.1f}%"
+
+
+def format_number(value):
+    if pd.isna(value):
+        return "N/A"
+
+    return f"{value:.3f}"
+
+
+st.markdown("# Model Reliability & Backtesting")
+st.markdown(
+    """
+    <p class="subtle-text">
+    This dashboard evaluates whether CricScope's win probability predictions are historically reliable.
+    It checks calibration, Brier Score, season-wise stability, innings-phase performance,
+    and pressure chase behavior.
+    </p>
+    """,
+    unsafe_allow_html=True,
+)
+
+with st.sidebar:
+    st.markdown("## Backtest Settings")
+    sample_size = st.slider(
+        "Historical match states to evaluate",
+        min_value=2000,
+        max_value=30000,
+        value=12000,
+        step=1000,
+        help="Higher values are more complete but may take longer to run.",
+    )
+
+    st.info(
+        "Backtesting trains on earlier seasons and evaluates on later seasons wherever possible."
+    )
+
+with st.spinner("Running historical model backtest..."):
+    match_states, predictions = build_backtest(sample_size)
+
+if predictions.empty:
+    st.error(
+        "Backtesting could not generate predictions. Please check matches.csv and deliveries.csv."
+    )
+    st.stop()
+
+summary = calculate_model_summary(predictions)
+calibration_table = create_probability_buckets(predictions)
+season_metrics = calculate_season_wise_metrics(predictions)
+phase_metrics = calculate_phase_wise_metrics(predictions)
+pressure_metrics = calculate_pressure_situation_metrics(predictions)
+
+st.markdown('<div class="section-title">Overall Reliability Summary</div>', unsafe_allow_html=True)
+
+col1, col2, col3, col4 = st.columns(4)
+
+with col1:
+    st.markdown(
+        f"""
+        <div class="metric-card">
+            <div class="metric-label">Evaluated States</div>
+            <div class="metric-value">{summary["samples"]:,}</div>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+with col2:
+    st.markdown(
+        f"""
+        <div class="metric-card">
+            <div class="metric-label">Accuracy</div>
+            <div class="metric-value">{format_percent(summary["accuracy"])}</div>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+with col3:
+    st.markdown(
+        f"""
+        <div class="metric-card">
+            <div class="metric-label">Brier Score</div>
+            <div class="metric-value">{format_number(summary["brier_score"])}</div>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+with col4:
+    st.markdown(
+        f"""
+        <div class="metric-card">
+            <div class="metric-label">Avg Confidence</div>
+            <div class="metric-value">{format_percent(summary["average_confidence"])}</div>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+st.caption(
+    "Brier Score measures probability reliability. Lower is better. "
+    "A perfectly calibrated model should have actual win rates close to predicted probabilities."
+)
+
+st.markdown('<div class="section-title">Calibration Curve</div>', unsafe_allow_html=True)
+
+curve_df = calibration_table.dropna(
+    subset=["average_predicted_probability", "actual_win_rate"]
+)
+
+fig = go.Figure()
+
+fig.add_trace(
+    go.Scatter(
+        x=[0, 1],
+        y=[0, 1],
+        mode="lines",
+        name="Perfect Calibration",
+        line=dict(dash="dash", color="#94a3b8"),
+    )
+)
+
+fig.add_trace(
+    go.Scatter(
+        x=curve_df["average_predicted_probability"],
+        y=curve_df["actual_win_rate"],
+        mode="lines+markers",
+        name="CricScope Calibration",
+        line=dict(color="#facc15", width=3),
+        marker=dict(size=9),
+    )
+)
+
+fig.update_layout(
+    xaxis_title="Average Predicted Win Probability",
+    yaxis_title="Actual Win Rate",
+    template="plotly_dark",
+    height=460,
+    margin=dict(l=20, r=20, t=30, b=20),
+)
+
+st.plotly_chart(fig, use_container_width=True)
+
+st.markdown('<div class="section-title">Probability Bucket Table</div>', unsafe_allow_html=True)
+
+display_calibration = calibration_table.copy()
+for col in [
+    "average_predicted_probability",
+    "actual_win_rate",
+    "calibration_gap",
+]:
+    display_calibration[col] = display_calibration[col].apply(format_percent)
+
+st.dataframe(display_calibration, use_container_width=True, hide_index=True)
+
+st.markdown('<div class="section-title">Season-wise Model Stability</div>', unsafe_allow_html=True)
+
+if not season_metrics.empty:
+    season_chart = px.bar(
+        season_metrics,
+        x="season",
+        y="brier_score",
+        hover_data=[
+            "samples",
+            "accuracy",
+            "average_predicted_probability",
+            "actual_win_rate",
+            "calibration_gap",
+        ],
+        title="Brier Score by Season",
+        template="plotly_dark",
+    )
+    season_chart.update_traces(marker_color="#facc15")
+    st.plotly_chart(season_chart, use_container_width=True)
+
+    season_display = season_metrics.copy()
+    for col in [
+        "accuracy",
+        "average_predicted_probability",
+        "actual_win_rate",
+        "calibration_gap",
+    ]:
+        season_display[col] = season_display[col].apply(format_percent)
+
+    season_display["brier_score"] = season_display["brier_score"].apply(format_number)
+    st.dataframe(season_display, use_container_width=True, hide_index=True)
+
+st.markdown('<div class="section-title">Innings Phase Performance</div>', unsafe_allow_html=True)
+
+if not phase_metrics.empty:
+    phase_chart = px.bar(
+        phase_metrics,
+        x="phase",
+        y="accuracy",
+        color="phase",
+        hover_data=[
+            "samples",
+            "brier_score",
+            "average_predicted_probability",
+            "actual_win_rate",
+            "calibration_gap",
+        ],
+        title="Accuracy by Match Phase",
+        template="plotly_dark",
+    )
+    st.plotly_chart(phase_chart, use_container_width=True)
+
+    phase_display = phase_metrics.copy()
+    for col in [
+        "accuracy",
+        "average_predicted_probability",
+        "actual_win_rate",
+        "calibration_gap",
+    ]:
+        phase_display[col] = phase_display[col].apply(format_percent)
+
+    phase_display["brier_score"] = phase_display["brier_score"].apply(format_number)
+    st.dataframe(phase_display, use_container_width=True, hide_index=True)
+
+st.markdown('<div class="section-title">Pressure Situation Analysis</div>', unsafe_allow_html=True)
+
+st.markdown(
+    """
+    <p class="subtle-text">
+    Pressure chase states are detected when required run rate is above 10,
+    balls left are below 30, wickets in hand are 4 or fewer, and runs left are above 40.
+    </p>
+    """,
+    unsafe_allow_html=True,
+)
+
+if not pressure_metrics.empty:
+    pressure_display = pressure_metrics.copy()
+
+    for col in [
+        "accuracy",
+        "average_predicted_probability",
+        "actual_win_rate",
+        "calibration_gap",
+    ]:
+        pressure_display[col] = pressure_display[col].apply(format_percent)
+
+    pressure_display["brier_score"] = pressure_display["brier_score"].apply(format_number)
+
+    st.dataframe(pressure_display, use_container_width=True, hide_index=True)
+
+with st.expander("What do these metrics mean?"):
+    st.markdown(
+        """
+        - **Brier Score:** Measures how close predicted probabilities are to actual outcomes. Lower is better.
+        - **Calibration Gap:** Actual win rate minus average predicted probability.
+        - **Probability Buckets:** Groups predictions into 0–10%, 10–20%, etc. to check reliability.
+        - **Season Stability:** Shows whether model quality changes across IPL seasons.
+        - **Phase Analysis:** Compares reliability in Powerplay, Middle Overs, and Death Overs.
+        - **Pressure Analysis:** Evaluates model behavior in difficult chase situations.
+        """
+    )

--- a/test_model_evaluation.py
+++ b/test_model_evaluation.py
@@ -1,0 +1,118 @@
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from model_evaluation import (
+    calculate_brier_score,
+    calculate_phase_wise_metrics,
+    calculate_pressure_situation_metrics,
+    calculate_season_wise_metrics,
+    classify_phase_from_balls_left,
+    create_probability_buckets,
+    is_pressure_situation,
+)
+
+
+class TestModelEvaluation(unittest.TestCase):
+    def test_brier_score(self):
+        y_true = [1, 0, 1, 0]
+        y_prob = [0.9, 0.2, 0.8, 0.1]
+
+        expected = np.mean([(0.9 - 1) ** 2, (0.2 - 0) ** 2, (0.8 - 1) ** 2, (0.1 - 0) ** 2])
+
+        self.assertAlmostEqual(calculate_brier_score(y_true, y_prob), expected)
+
+    def test_phase_classification(self):
+        self.assertEqual(classify_phase_from_balls_left(100), "Powerplay")
+        self.assertEqual(classify_phase_from_balls_left(60), "Middle Overs")
+        self.assertEqual(classify_phase_from_balls_left(20), "Death Overs")
+
+    def test_pressure_situation_true(self):
+        row = pd.Series(
+            {
+                "rrr": 12,
+                "balls_left": 24,
+                "wickets": 3,
+                "runs_left": 50,
+            }
+        )
+
+        self.assertTrue(is_pressure_situation(row))
+
+    def test_pressure_situation_false(self):
+        row = pd.Series(
+            {
+                "rrr": 8,
+                "balls_left": 50,
+                "wickets": 7,
+                "runs_left": 30,
+            }
+        )
+
+        self.assertFalse(is_pressure_situation(row))
+
+    def test_probability_buckets(self):
+        predictions = pd.DataFrame(
+            {
+                "win_probability": [0.05, 0.15, 0.75, 0.85],
+                "result": [0, 0, 1, 1],
+            }
+        )
+
+        buckets = create_probability_buckets(predictions)
+
+        self.assertIn("prediction_bucket", buckets.columns)
+        self.assertIn("sample_count", buckets.columns)
+        self.assertIn("calibration_gap", buckets.columns)
+        self.assertEqual(int(buckets["sample_count"].sum()), 4)
+
+    def test_season_wise_metrics(self):
+        predictions = pd.DataFrame(
+            {
+                "season": [2018, 2018, 2019, 2019],
+                "win_probability": [0.8, 0.3, 0.6, 0.4],
+                "result": [1, 0, 1, 0],
+                "correct_prediction": [1, 1, 1, 1],
+            }
+        )
+
+        metrics = calculate_season_wise_metrics(predictions)
+
+        self.assertEqual(len(metrics), 2)
+        self.assertIn("brier_score", metrics.columns)
+        self.assertIn("accuracy", metrics.columns)
+
+    def test_phase_wise_metrics(self):
+        predictions = pd.DataFrame(
+            {
+                "phase": ["Powerplay", "Powerplay", "Death Overs", "Death Overs"],
+                "win_probability": [0.7, 0.4, 0.8, 0.2],
+                "result": [1, 0, 1, 0],
+                "correct_prediction": [1, 1, 1, 1],
+            }
+        )
+
+        metrics = calculate_phase_wise_metrics(predictions)
+
+        self.assertEqual(len(metrics), 2)
+        self.assertIn("calibration_gap", metrics.columns)
+
+    def test_pressure_metrics(self):
+        predictions = pd.DataFrame(
+            {
+                "pressure_situation": [True, True, False],
+                "win_probability": [0.25, 0.7, 0.9],
+                "result": [0, 1, 1],
+                "correct_prediction": [1, 1, 1],
+            }
+        )
+
+        metrics = calculate_pressure_situation_metrics(predictions)
+
+        self.assertEqual(len(metrics), 1)
+        self.assertEqual(metrics.iloc[0]["samples"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #235

This PR adds a new **Model Reliability & Backtesting** dashboard for CricScope’s win probability prediction system.

The dashboard helps evaluate how trustworthy the model probabilities are by showing calibration metrics, historical backtesting results, season-wise stability, innings-phase performance, and pressure chase analysis.

## Changes Made

- Added a new `model_evaluation.py` utility module.
- Added historical backtesting logic for IPL match states.
- Added Brier Score calculation for probability reliability.
- Added probability bucket generation.
- Added calibration gap calculation.
- Added season-wise model stability metrics.
- Added phase-wise performance metrics for:
  - Powerplay
  - Middle Overs
  - Death Overs
- Added pressure chase situation analysis.
- Added a new Streamlit page:

```txt
pages/Model_Reliability_Backtesting.py
```

- Added calibration curve visualization.
- Added probability bucket table.
- Added season-wise and phase-wise performance charts.
- Added unit tests for model evaluation calculations.

## Testing

Ran:

```bash
python -m unittest -v test_model_evaluation.py
```

Also ran:

```bash
python -m unittest -v test_calculations.py test_model_evaluation.py
```

Manual testing:

```bash
streamlit run application.py
```

Verified that the new **Model Reliability & Backtesting** page loads and displays:

- Overall reliability summary
- Calibration curve
- Probability bucket table
- Season-wise metrics
- Phase-wise metrics
- Pressure situation analysis

## Notes

This feature is added as a separate Streamlit page, so the existing win probability prediction flow remains unaffected.