### PR TITLE
test: expand CricScope calculations suite with boundary edge cases

### DIFF
--- a/test_calculations.py
+++ b/test_calculations.py
@@ -88,6 +88,31 @@ class TestCricScopeCalculations(unittest.TestCase):
         self.assertEqual(crr, 7.5)
         self.assertEqual(rrr, 0.0)
 
+    def test_extreme_targets_and_scores(self):
+        # Extreme target (e.g. 500 runs) and extremely high overs
+        runs_left, balls_left, crr, rrr = calculate_prediction_inputs(500, 450, 19.5)
+        self.assertEqual(runs_left, 50)
+        self.assertEqual(balls_left, 3)
+        self.assertAlmostEqual(crr, 450 / 19.5, places=4)
+        self.assertAlmostEqual(rrr, (50 * 6) / 3, places=4)
+
+    def test_negative_runs_left(self):
+        # When target is already exceeded (score > target)
+        runs_left, balls_left, crr, rrr = calculate_prediction_inputs(100, 120, 15)
+        self.assertEqual(runs_left, -20)
+        self.assertEqual(balls_left, 30)
+        self.assertEqual(crr, 8.0)
+        # RRR should go negative to indicate winning rate is already exceeded
+        self.assertEqual(rrr, -4.0)
+
+    def test_zero_runs_needed_perfect_boundary(self):
+        # Tie-score scenario (score == target)
+        runs_left, balls_left, crr, rrr = calculate_prediction_inputs(150, 150, 18)
+        self.assertEqual(runs_left, 0)
+        self.assertEqual(balls_left, 12)
+        self.assertEqual(crr, 150 / 18)
+        self.assertEqual(rrr, 0.0)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Closes #308 

## Description
This pull request hardens CricScope's core mathematical and statistical validation layers by broadening the unit testing suite in `test_calculations.py`. The added test cases verify extreme boundary states and mathematical edge cases, ensuring that CricScope's calculation algorithms function reliably under all scenarios without raising errors.

### Changes Made:
* **File Modified**: `test_calculations.py`
  * Added `test_extreme_targets_and_scores` to verify run-rate math on extreme matches (e.g. targets up to 500 runs).
  * Added `test_negative_runs_left` to verify chasing run rate calculation when the chasing team has already exceeded the target (score > target, causing negative runs left).
  * Added `test_zero_runs_needed_perfect_boundary` to verify tie scenarios (score == target) at exact innings boundaries.

## Verification Results
* The expanded test suite was executed locally.
* Total test cases increased from 6 to 9, with all 9 tests passing successfully (`Ran 9 tests in 0.022s ... OK`).
