### PR TITLE
Add momentum regime detection and UI summary

### DIFF
--- a/application.py
+++ b/application.py
@@ -37,6 +37,8 @@ from sklearn.metrics import accuracy_score, precision_score, recall_score, f1_sc
 from sklearn.ensemble import RandomForestClassifier
 from xgboost import XGBClassifier
 
+from momentum import classify_momentum_regime
+
 logging.basicConfig(level=logging.INFO)
 
 # -----------------------------------
@@ -1684,6 +1686,10 @@ if st.session_state.page == "Analysis":
                 win = proba[1]
                 lose = proba[0]
 
+        momentum_label, momentum_explanation = classify_momentum_regime(
+            win, lose, crr, rrr, 10 - wickets, balls_left
+        )
+
         st.markdown('<div style="height:28px;"></div>', unsafe_allow_html=True)
         st.markdown("""
             <div style="font-size:10px;letter-spacing:3px;text-transform:uppercase;
@@ -1793,6 +1799,21 @@ if st.session_state.page == "Analysis":
                     <div style="font-family:'Cormorant Garamond',serif;font-size:22px;
                                 font-weight:500;color:#f0e8cc;">
                         {verdict} favoured to win
+                    </div>
+                    <div style="font-size:11px;color:rgba(215,205,170,0.85);margin-top:10px;line-height:1.45;">
+                        <strong>{momentum_label}</strong> — {momentum_explanation}
+                    </div>
+                </div>
+                <div style="text-align:right;">
+                    <div style="font-size:9px;letter-spacing:2px;text-transform:uppercase;
+                                color:rgba(212,175,55,0.35);margin-bottom:6px;">Confidence</div>
+                    <div style="font-family:'DM Mono',monospace;font-size:20px;color:#d4af37;">
+                        {conf_label} · {round(conf*100)}%
+                    </div>
+                </div>
+            </div>
+        """, unsafe_allow_html=True)
+
                     </div>
                 </div>
                 <div style="text-align:right;">

--- a/momentum.py
+++ b/momentum.py
@@ -1,0 +1,50 @@
+def classify_momentum_regime(win, lose, crr, rrr, wickets_in_hand, balls_left):
+    """Classify the current match momentum regime from probability and rate context."""
+    if balls_left <= 0:
+        return "Match Complete", "The innings is finished, so no active momentum phase applies."
+    if wickets_in_hand <= 0:
+        return "Bowling Dominance", "All wickets are gone and the bowling side has the upper hand."
+
+    if win >= 0.75:
+        return (
+            "Batting Dominance",
+            "The batting side is in strong control and is likely to close out the chase unless momentum abruptly shifts."
+        )
+    if lose >= 0.75:
+        return (
+            "Bowling Dominance",
+            "The bowling side is applying sustained pressure and is in a commanding position."
+        )
+
+    if balls_left <= 12:
+        if abs(win - lose) <= 0.15:
+            return (
+                "Clutch Moment",
+                "The match is now in a high-pressure final phase where one over can decide the outcome."
+            )
+        return (
+            "Clutch Defense" if lose > win else "Clutch Chase",
+            "The final overs are approaching and this is a tense phase for both sides."
+        )
+
+    if wickets_in_hand <= 4 and rrr > crr + 1.5 and win < 0.6:
+        return (
+            "Collapse Risk",
+            "The batting side faces a serious collapse risk unless it accelerates and protects the remaining wickets."
+        )
+
+    if abs(crr - rrr) >= 1.5:
+        if crr > rrr:
+            return (
+                "Batting Momentum",
+                "The batting side is scoring faster than the required rate and is building momentum."
+            )
+        return (
+            "Bowling Pressure",
+            "The bowling side has forced the batting side into a higher required run rate and is dictating the contest."
+        )
+
+    return (
+        "Balanced Contest",
+        "The match is evenly poised and momentum can swing quickly in either direction."
+    )

--- a/test_calculations.py
+++ b/test_calculations.py
@@ -2,6 +2,8 @@ import unittest
 import pandas as pd
 import numpy as np
 
+from momentum import classify_momentum_regime
+
 # Helper functions replicating the implementation logic in application.py
 def calculate_balls_left_df(over, ball):
     # Replicates pandas training logic
@@ -87,6 +89,28 @@ class TestCricScopeCalculations(unittest.TestCase):
         self.assertEqual(balls_left, 0)
         self.assertEqual(crr, 7.5)
         self.assertEqual(rrr, 0.0)
+
+    def test_classify_momentum_regime(self):
+        self.assertEqual(
+            classify_momentum_regime(0.82, 0.18, 7.8, 6.2, 6, 36)[0],
+            "Batting Dominance"
+        )
+        self.assertEqual(
+            classify_momentum_regime(0.25, 0.75, 5.5, 7.2, 8, 45)[0],
+            "Bowling Dominance"
+        )
+        self.assertEqual(
+            classify_momentum_regime(0.52, 0.48, 7.0, 9.0, 3, 15)[0],
+            "Collapse Risk"
+        )
+        self.assertEqual(
+            classify_momentum_regime(0.55, 0.45, 6.8, 8.4, 7, 14)[0],
+            "Bowling Pressure"
+        )
+        self.assertEqual(
+            classify_momentum_regime(0.5, 0.5, 6.2, 6.0, 6, 40)[0],
+            "Balanced Contest"
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Issue #170 

### Summary
Add a match momentum regime detection layer to the existing win probability analytics.

### What changed
- Added momentum.py with `classify_momentum_regime(...)`
- Integrated momentum classification into application.py
- Displayed momentum regime label + explanation in the prediction summary
- Added regression tests in test_calculations.py

### Why
- Moves beyond raw win probability by identifying contextual match phases
- Surfaces states like batting dominance, bowling dominance, collapse risk, clutch moments, and balanced contests
- Makes analytics more interpretable and cricket-aware

### Validation
- `python -m unittest test_calculations.py` ✅