### PR TITLE
Docs: fix Streamlit entrypoint and dataset setup guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,11 @@ source venv/bin/activate
 Install Dependencies
 pip install -r requirements.txt
 Run the Application
-streamlit run app.py
+streamlit run application.py
+
+Note: `application.py` is the repo's current Streamlit entrypoint, so using it avoids a dead-end for first-time contributors.
+
+Required datasets: place `matches.csv` and `deliveries.csv` in the project root before launching the app. The dataset source and file purpose are documented in `dataset_info.txt`.
 
 The app will start locally at:
 

--- a/README.md
+++ b/README.md
@@ -426,6 +426,10 @@ git push origin feature/your-feature-name
 - Write meaningful commit messages
 - Respect UI consistency
 
+### Local Setup Notes
+
+The app needs `matches.csv` and `deliveries.csv` in the project root before you run it locally. The dataset source and file details are documented in [dataset_info.txt](dataset_info.txt).
+
 ---
 ## 🔐 Security Policy
 


### PR DESCRIPTION
## Summary

This PR improves the contributor onboarding and local setup documentation.

The previous setup instructions were missing some important details required to run the project successfully for first-time contributors.

## Changes Made

### CONTRIBUTING.md

* Fixed the Streamlit launch command:

  * from `streamlit run app.py`
  * to `streamlit run application.py`
* Added a short clarification note about the correct application entrypoint
* Added setup notes explaining that:

  * `matches.csv`
  * `deliveries.csv`
    must exist in the project root before running the app
* Added a reference to `dataset_info.txt` for dataset source details

### README.md

* Added a compact dataset setup note
* Referenced `dataset_info.txt` for contributor guidance about required datasets

## Why

Previously:

* contributors could hit a dead end because `app.py` does not exist as the Streamlit entrypoint
* dataset requirements were not clearly documented
* new contributors were not told where the required CSV files come from

This update aligns the documentation with the actual project structure and improves the onboarding experience for contributors setting up the project locally.

## Validation

* Verified changes using `git diff`
* Kept the update scoped only to:

  * `README.md`
  * `CONTRIBUTING.md`
