### PR TITLE
fix: show clear dataset load errors

### DIFF
--- a/application.py
+++ b/application.py
@@ -40,6 +40,26 @@ from venue_intelligence import render_venue_intelligence
 
 logging.basicConfig(level=logging.INFO)
 
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def load_required_dataset(filename):
+    dataset_path = os.path.join(BASE_DIR, filename)
+    try:
+        return pd.read_csv(dataset_path)
+    except FileNotFoundError:
+        st.error(
+            f"Required dataset file '{filename}' was not found. "
+            "Please keep matches.csv and deliveries.csv in the project root before running CricScope."
+        )
+        st.stop()
+    except pd.errors.EmptyDataError:
+        st.error(f"Dataset file '{filename}' is empty. Please restore a valid copy and restart the app.")
+        st.stop()
+    except pd.errors.ParserError as exc:
+        st.error(f"Dataset file '{filename}' could not be parsed: {exc}")
+        st.stop()
+
 
 
 # -----------------------------------
@@ -938,8 +958,8 @@ def train_model(model_name='logistic'):
         except Exception as e:
             logging.error(f"Failed to load cached model from {model_path}: {e}")
 
-    matches = pd.read_csv("matches.csv")
-    deliveries = pd.read_csv("deliveries.csv")
+    matches = load_required_dataset("matches.csv")
+    deliveries = load_required_dataset("deliveries.csv")
 
     df = deliveries.merge(matches, left_on='match_id', right_on='id')
 
@@ -1013,8 +1033,8 @@ def train_model(model_name='logistic'):
 def evaluate_model(model_name='logistic'):
     pipe = train_model(model_name)
 
-    matches = pd.read_csv("matches.csv")
-    deliveries = pd.read_csv("deliveries.csv")
+    matches = load_required_dataset("matches.csv")
+    deliveries = load_required_dataset("deliveries.csv")
 
     df = deliveries.merge(matches, left_on='match_id', right_on='id')
 
@@ -1896,7 +1916,7 @@ if st.session_state.page == "Team Analysis":
 
     team = st.session_state.selected_team
     
-    matches_df = pd.read_csv("matches.csv")
+    matches_df = load_required_dataset("matches.csv")
 
     team_matches = matches_df[
         (matches_df["team1"] == team) |
@@ -1987,7 +2007,7 @@ if st.session_state.page == "Team Analysis":
      # Team Strength Analysis
         st.subheader("📈 Team Statistics")
         
-        deliveries_df = pd.read_csv("deliveries.csv")
+        deliveries_df = load_required_dataset("deliveries.csv")
 
         team_batting = deliveries_df[
         deliveries_df["batting_team"] == team


### PR DESCRIPTION
## Summary\n- load required CSV files through a shared helper anchored to the project root\n- show clear Streamlit errors for missing, empty, or malformed dataset files instead of raw pandas tracebacks\n- keep the existing model/data preparation flow unchanged when files are valid\n\nFixes #366\n\n## Validation\n- python -m unittest test_calculations.py