### PR TITLE
fix: configure Streamlit page before rendering

### DIFF
--- a/application.py
+++ b/application.py
@@ -1,4 +1,12 @@
 import streamlit as st
+
+st.set_page_config(
+    page_title="CricScope",
+    page_icon="🏏",
+    layout="wide",
+    initial_sidebar_state="expanded",
+)
+
 st.markdown("""
 <style>
 


### PR DESCRIPTION
## Summary\n- call st.set_page_config immediately after importing Streamlit\n- keep all CSS/markdown rendering after page configuration to avoid startup errors\n\nFixes #286\n\n## Validation\n- python -m py_compile application.py\n- python -m unittest test_calculations.py