### PR TITLE
[GSSoC'26] fix: resolve raw HTML display of confusion matrix on Model Performance page

### DIFF
--- a/application.py
+++ b/application.py
@@ -27,6 +27,7 @@ import time
 import os
 import joblib
 import logging
+import textwrap
 
 from sklearn.compose import ColumnTransformer
 from sklearn.preprocessing import OneHotEncoder
@@ -1426,14 +1427,14 @@ elif st.session_state.page == "Performance":
         """, unsafe_allow_html=True)
         
     with col_cm:
-        st.markdown(f"""
+        st.markdown(textwrap.dedent(f"""
             <div class="matrix-wrapper">
                 <div class="input-label" style="font-size:11px; margin-bottom: 8px;">Confusion Matrix</div>
                 <div style="font-size:12px; color:rgba(220,210,185,0.45); margin-bottom: 20px; line-height:1.4;">
                     A tabular layout visualizing classification hits and misses. Gold-bordered diagonal cells represent correct predictions.
                 </div>
                 <div class="matrix-grid">
-                    <div class="matrix-header">Actual \\ Pred</div>
+                    <div class="matrix-header">Actual \\\\ Pred</div>
                     <div class="matrix-header">Bowl Win (0)</div>
                     <div class="matrix-header">Bat Win (1)</div>
                     
@@ -1458,7 +1459,7 @@ elif st.session_state.page == "Performance":
                     </div>
                 </div>
             </div>
-        """, unsafe_allow_html=True)
+        """), unsafe_allow_html=True)
 
     # Fold scores display
     st.markdown('<div style="height:32px;"></div>', unsafe_allow_html=True)


### PR DESCRIPTION
Resolves #324.

### 🌟 Contribution Statement
I am contributing on behalf of **GSSoc'26**.

### 📝 Description
This PR resolves the issue where raw HTML `<div>` tags were displayed instead of a rendered confusion matrix on the Model Performance page. The bug was caused by:
1. **Markdown Indentation**: The HTML string inside `st.markdown()` was indented with 12 spaces, which the markdown parser interprets as an indented code block (`<pre><code>`). We wrapped it in `textwrap.dedent()` to automatically strip common leading whitespace.
2. **Backslash String Escape**: The header `"Actual \ Pred"` was escaping the space/newline or breaking the markdown-it parser. We properly escaped it to `"Actual \\\\ Pred"`.

### 🛡️ Verification
- Verified that `application.py` compiles and runs successfully.
- Verified that the Confusion Matrix now renders as a beautiful, premium table instead of showing raw HTML code.
