### PR TITLE
[GSSoC'26] fix: resolve edge-case prediction crashes with robust input validation

### DIFF
--- a/application.py
+++ b/application.py
@@ -1616,6 +1616,24 @@ if st.session_state.page == "Analysis":
 
     # ---- PREDICTION OUTPUT ----
     if analyze:
+        # ---- INPUT VALIDATION LAYER ----
+        errors = []
+        if target <= 0:
+            errors.append("❌ Target score must be greater than 0.")
+        if score < 0:
+            errors.append("❌ Current score cannot be negative.")
+        if score >= target:
+            errors.append("❌ Current score cannot be greater than or equal to the target.")
+        if wickets < 0 or wickets > 10:
+            errors.append("❌ Wickets fallen must be between 0 and 10.")
+        if overs < 0 or overs > 20:
+            errors.append("❌ Overs completed must be between 0 and 20.")
+            
+        if errors:
+            for msg in errors:
+                st.error(msg)
+            st.stop()
+
         runs_left, balls_left, crr, rrr = safe_calculate_rates(score, target, overs)
 
         input_df = pd.DataFrame({

--- a/pages/live_match.py
+++ b/pages/live_match.py
@@ -730,6 +730,24 @@ if not user_api_key:
     if st.button("🔮 Predict Win Probability", key="demo_predict", use_container_width=True):
         demo_runs, demo_wickets = parse_score_string(demo_score_str)
         if demo_runs is not None and demo_wickets is not None:
+            # ---- INPUT VALIDATION LAYER ----
+            errors = []
+            if demo_target <= 0:
+                errors.append("❌ Target score must be greater than 0.")
+            if demo_runs < 0:
+                errors.append("❌ Current score cannot be negative.")
+            if demo_runs >= demo_target:
+                errors.append("❌ Current score cannot be greater than or equal to the target.")
+            if demo_wickets < 0 or demo_wickets > 10:
+                errors.append("❌ Wickets fallen must be between 0 and 10.")
+            if demo_overs < 0 or demo_overs > 20:
+                errors.append("❌ Overs completed must be between 0 and 20.")
+                
+            if errors:
+                for msg in errors:
+                    st.error(msg)
+                st.stop()
+
             result = compute_prediction(
                 demo_bat, demo_bowl, demo_venue,
                 demo_target, demo_runs, demo_wickets, demo_overs,


### PR DESCRIPTION
Resolves #376.

### 🌟 Contribution Statement
I am contributing on behalf of **GSSoc'26**.

### 📝 Description
This PR addresses edge-case numeric inputs in match prediction forms to prevent crashes and mathematical inconsistencies. The following safety validations have been added to the match analysis page (`application.py`) and the live match manual mode (`pages/live_match.py`):
1. **Target Score**: Assures `target > 0` to prevent division-by-zero errors when calculating rates.
2. **Current Score**: Blocks scores that exceed or equal the target (`score >= target`), as well as negative scores.
3. **Wickets Fallen**: Restricts wickets to values between `0` and `10` inclusive.
4. **Overs Completed**: Restricts overs to values between `0` and `20` inclusive to maintain logical alignment with T20 cricket formats.

When an illegal input value is triggered, clean, specific `st.error()` warning messages are surfaced and the downstream prediction execution is halted cleanly with `st.stop()`.

### 🛡️ Verification
- Verified that invalid inputs (e.g., setting target=0 or current score higher than target) cleanly block predictions and render helpful error messages rather than causing a ZeroDivisionError/ValueError crash.
