### PR TITLE
fix(stats): use selected teams for head-to-head records

### DIFF
--- a/pages/stats.py
+++ b/pages/stats.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import streamlit as st
 import plotly.graph_objects as go
+from stats_utils import calculate_head_to_head_record
 #  page config 
 st.set_page_config(
     page_title="CricScope · Stats",
@@ -251,43 +252,33 @@ with col1:
 with col2:
     remaining = [t for t in all_teams if t != team_a]
     team_b = st.selectbox("Team B", remaining, index=remaining.index("Chennai Super Kings") if "Chennai Super Kings" in remaining else 0, key="h2h_b")
-    
-#Example value
-team_a = "Chennai Super KIngs"
-team_b = "Mumbai Indians"
 
-team_a_wins = 11
-team_b_wins = 17
+record = calculate_head_to_head_record(matches, team_a, team_b)
 
-#Pie Chart
-fig = go.Figure(data=[go.Pie(
-    labels=[f"{team_a}Wins",f"{team_b}Wins"],
-    values=[11,17],
-    hole=0.5
-)])
-
-fig.update_layout(
-    paper_bgcolor="#0E1117",
-    font_color="white",
-    margin=dict(l=20,r=20,t=20,b=20))
-
-st.plotly_chart(fig, use_container_width=True)
-# filter h2h matches
-h2h = matches[
-    ((matches["team1"] == team_a) & (matches["team2"] == team_b)) |
-    ((matches["team1"] == team_b) & (matches["team2"] == team_a))
-].copy()
-
-if h2h.empty:
+if record["matches"].empty:
     st.info("No head-to-head matches found between these two teams.")
 else:
-    total = len(h2h)
-    a_wins = (h2h["winner"] == team_a).sum()
-    b_wins = (h2h["winner"] == team_b).sum()
-    no_result = total - a_wins - b_wins
+    # Pie Chart
+    fig = go.Figure(data=[go.Pie(
+        labels=[f"{team_a} Wins", f"{team_b} Wins", "No Result"],
+        values=[record["team_a_wins"], record["team_b_wins"], record["no_result"]],
+        hole=0.5
+    )])
 
-    a_pct = round(a_wins / total * 100, 1) if total else 0
-    b_pct = round(b_wins / total * 100, 1) if total else 0
+    fig.update_layout(
+        paper_bgcolor="#0E1117",
+        font_color="white",
+        margin=dict(l=20,r=20,t=20,b=20))
+
+    st.plotly_chart(fig, use_container_width=True)
+
+    h2h = record["matches"]
+    total = record["total"]
+    a_wins = record["team_a_wins"]
+    b_wins = record["team_b_wins"]
+    no_result = record["no_result"]
+    a_pct = record["team_a_pct"]
+    b_pct = record["team_b_pct"]
 
     ca, cb, cc = st.columns(3)
     with ca:

--- a/stats_utils.py
+++ b/stats_utils.py
@@ -1,0 +1,21 @@
+def calculate_head_to_head_record(matches, team_a, team_b):
+    """Calculate head-to-head results for two selected teams."""
+    h2h = matches[
+        ((matches["team1"] == team_a) & (matches["team2"] == team_b))
+        | ((matches["team1"] == team_b) & (matches["team2"] == team_a))
+    ].copy()
+
+    total = len(h2h)
+    team_a_wins = int((h2h["winner"] == team_a).sum())
+    team_b_wins = int((h2h["winner"] == team_b).sum())
+    no_result = total - team_a_wins - team_b_wins
+
+    return {
+        "matches": h2h,
+        "total": total,
+        "team_a_wins": team_a_wins,
+        "team_b_wins": team_b_wins,
+        "no_result": no_result,
+        "team_a_pct": round(team_a_wins / total * 100, 1) if total else 0,
+        "team_b_pct": round(team_b_wins / total * 100, 1) if total else 0,
+    }

--- a/stats_utils.py
+++ b/stats_utils.py
@@ -1,5 +1,14 @@
-def calculate_head_to_head_record(matches, team_a, team_b):
-    """Calculate head-to-head results for two selected teams."""
+from typing import Any
+
+import pandas as pd
+
+
+def calculate_head_to_head_record(
+    matches: pd.DataFrame,
+    team_a: str,
+    team_b: str,
+) -> dict[str, Any]:
+    """Calculate head-to-head results from team1, team2, and winner columns."""
     h2h = matches[
         ((matches["team1"] == team_a) & (matches["team2"] == team_b))
         | ((matches["team1"] == team_b) & (matches["team2"] == team_a))
@@ -16,6 +25,6 @@ def calculate_head_to_head_record(matches, team_a, team_b):
         "team_a_wins": team_a_wins,
         "team_b_wins": team_b_wins,
         "no_result": no_result,
-        "team_a_pct": round(team_a_wins / total * 100, 1) if total else 0,
-        "team_b_pct": round(team_b_wins / total * 100, 1) if total else 0,
+        "team_a_pct": round(team_a_wins / total * 100, 1) if total else 0.0,
+        "team_b_pct": round(team_b_wins / total * 100, 1) if total else 0.0,
     }

--- a/test_calculations.py
+++ b/test_calculations.py
@@ -124,6 +124,27 @@ class TestCricScopeCalculations(unittest.TestCase):
         self.assertEqual(record["team_a_pct"], 50.0)
         self.assertEqual(record["team_b_pct"], 50.0)
 
+    def test_head_to_head_record_handles_no_matches(self):
+        matches = pd.DataFrame({
+            "team1": ["Mumbai Indians"],
+            "team2": ["Chennai Super Kings"],
+            "winner": ["Mumbai Indians"],
+        })
+
+        record = calculate_head_to_head_record(
+            matches,
+            "Royal Challengers Bangalore",
+            "Rajasthan Royals",
+        )
+
+        self.assertTrue(record["matches"].empty)
+        self.assertEqual(record["total"], 0)
+        self.assertEqual(record["team_a_wins"], 0)
+        self.assertEqual(record["team_b_wins"], 0)
+        self.assertEqual(record["no_result"], 0)
+        self.assertEqual(record["team_a_pct"], 0.0)
+        self.assertEqual(record["team_b_pct"], 0.0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_calculations.py
+++ b/test_calculations.py
@@ -1,6 +1,7 @@
 import unittest
 import pandas as pd
 import numpy as np
+from stats_utils import calculate_head_to_head_record
 
 # Helper functions replicating the implementation logic in application.py
 def calculate_balls_left_df(over, ball):
@@ -87,6 +88,41 @@ class TestCricScopeCalculations(unittest.TestCase):
         self.assertEqual(balls_left, 0)
         self.assertEqual(crr, 7.5)
         self.assertEqual(rrr, 0.0)
+
+    def test_head_to_head_record_uses_selected_teams(self):
+        matches = pd.DataFrame({
+            "team1": [
+                "Mumbai Indians",
+                "Chennai Super Kings",
+                "Mumbai Indians",
+                "Royal Challengers Bangalore",
+            ],
+            "team2": [
+                "Chennai Super Kings",
+                "Mumbai Indians",
+                "Royal Challengers Bangalore",
+                "Mumbai Indians",
+            ],
+            "winner": [
+                "Mumbai Indians",
+                "Chennai Super Kings",
+                None,
+                "Royal Challengers Bangalore",
+            ],
+        })
+
+        record = calculate_head_to_head_record(
+            matches,
+            "Mumbai Indians",
+            "Chennai Super Kings",
+        )
+
+        self.assertEqual(record["total"], 2)
+        self.assertEqual(record["team_a_wins"], 1)
+        self.assertEqual(record["team_b_wins"], 1)
+        self.assertEqual(record["no_result"], 0)
+        self.assertEqual(record["team_a_pct"], 50.0)
+        self.assertEqual(record["team_b_pct"], 50.0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What
Fixes #356. The Stats page Head-to-Head section now respects the selected Team A and Team B instead of overwriting them with hardcoded Chennai/Mumbai demo values.

## How
Added a small `calculate_head_to_head_record` helper for dataset-driven matchup totals, reused that result for the pie chart, stat cards, percentages, no-result count, and recent encounters. The chart is only rendered when matching records exist.

## Testing
- `python3 -m py_compile application.py pages/stats.py pages/live_match.py venue_intelligence.py cricket_agent.py voice_input.py test_calculations.py stats_utils.py`
- `git diff --check`
- `venv/bin/python -m unittest test_calculations.py` (8 tests)
- `streamlit run pages/stats.py --server.headless true --server.port 8502 --browser.gatherUsageStats false`, then `curl -I http://localhost:8502` returned `200 OK`

## Risks / Notes
No migrations or dependency changes. Local virtual environments used for verification were removed before commit. Copilot review comments were addressed in the follow-up commit and resolved.