### PR TITLE
fix: short-circuit model call when innings is complete (issue #353)

### DIFF
--- a/pages/live_match.py
+++ b/pages/live_match.py
@@ -550,12 +550,32 @@ def compute_prediction(batting_team, bowling_team, venue, target,
         runs_left = target - current_score
         balls_left = 120 - total_balls_bowled
 
-        if balls_left <= 0:
-            balls_left = 1  # avoid division by zero at end of innings
-
         wickets_in_hand = 10 - wickets_fallen
         crr = current_score / (total_balls_bowled / 6) if total_balls_bowled > 0 else 0
-        rrr = (runs_left * 6) / balls_left if balls_left > 0 else 0
+
+        # Short-circuit: innings already completed — do NOT call the model
+        if balls_left <= 0 or wickets_fallen >= 10:
+            if current_score >= target:
+                return {
+                    "batting_win": 100,
+                    "bowling_win": 0,
+                    "crr": round(crr, 2),
+                    "rrr": 0.0,
+                    "runs_left": runs_left,
+                    "balls_left": max(0, balls_left),
+                    "wickets_in_hand": wickets_in_hand,
+                }
+            return {
+                "batting_win": 0,
+                "bowling_win": 100,
+                "crr": round(crr, 2),
+                "rrr": 0.0,
+                "runs_left": runs_left,
+                "balls_left": max(0, balls_left),
+                "wickets_in_hand": wickets_in_hand,
+            }
+
+        rrr = (runs_left * 6) / balls_left
 
         # Use a generic city if venue is unknown
         city = venue if venue else "Mumbai"


### PR DESCRIPTION
## Problem
When innings completed (balls_left <= 0), the code forced balls_left = 1 to avoid division-by-zero, then fed these fabricated out-of-distribution states into predict_proba(), returning misleading probabilities for already-decided matches.

## Fix
Added a short-circuit guard in compute_prediction() before any feature construction or model call.

## Changes
- Removed fabricated `balls_left = 1` workaround
- Added guard: when `balls_left <= 0` or `wickets_fallen >= 10`, return deterministic result without calling the model
- `batting_win = 100` if `current_score >= target`
- `batting_win = 0` if innings over and target not reached
- Mid-innings prediction behavior fully unchanged
- Return dict shape kept consistent with model path

## Verification
| Case | State | Result |
|---|---|---|
| Batting team lost | overs=20.0, score=150, target=185 | batting_win=0, no model call |
| Batting team won | overs=20.0, score=190, target=185 | batting_win=100, no model call |
| Innings in progress | overs=10.0, score=80, target=150 | normal model path unchanged |

Closes #353