### PR TITLE
fix: resolve hardcoded team matchup overrides and dynamic pie chart rendering in matchup records

### DIFF
--- a/pages/stats.py
+++ b/pages/stats.py
@@ -251,27 +251,6 @@ with col1:
 with col2:
     remaining = [t for t in all_teams if t != team_a]
     team_b = st.selectbox("Team B", remaining, index=remaining.index("Chennai Super Kings") if "Chennai Super Kings" in remaining else 0, key="h2h_b")
-    
-#Example value
-team_a = "Chennai Super KIngs"
-team_b = "Mumbai Indians"
-
-team_a_wins = 11
-team_b_wins = 17
-
-#Pie Chart
-fig = go.Figure(data=[go.Pie(
-    labels=[f"{team_a}Wins",f"{team_b}Wins"],
-    values=[11,17],
-    hole=0.5
-)])
-
-fig.update_layout(
-    paper_bgcolor="#0E1117",
-    font_color="white",
-    margin=dict(l=20,r=20,t=20,b=20))
-
-st.plotly_chart(fig, use_container_width=True)
 # filter h2h matches
 h2h = matches[
     ((matches["team1"] == team_a) & (matches["team2"] == team_b)) |
@@ -288,6 +267,23 @@ else:
 
     a_pct = round(a_wins / total * 100, 1) if total else 0
     b_pct = round(b_wins / total * 100, 1) if total else 0
+
+    #Pie Chart
+    fig = go.Figure(data=[go.Pie(
+        labels=[f"{team_a} Wins", f"{team_b} Wins", "No Result"],
+        values=[a_wins, b_wins, no_result],
+        hole=0.5,
+        marker=dict(colors=["#d4af37", "#4ecdc4", "rgba(255,255,255,0.1)"])
+    )])
+
+    fig.update_layout(
+        paper_bgcolor="rgba(0,0,0,0)",
+        plot_bgcolor="rgba(0,0,0,0)",
+        font_color="white",
+        margin=dict(l=20,r=20,t=20,b=20)
+    )
+
+    st.plotly_chart(fig, use_container_width=True)
 
     ca, cb, cc = st.columns(3)
     with ca:


### PR DESCRIPTION
Closes #405 

# Related Issue
Closes #ISSUE_NUMBER

# Summary
This PR fixes a bug on the statistics page where team selections for the head-to-head matchup comparison were overridden by static hardcoded values, displaying incorrect and static chart information.

# Changes Made
- Removed hardcoded `team_a`, `team_b`, and static wins overrides in `pages/stats.py`.
- Moved Plotly donut chart generation to the dynamic calculations block within the `else` branch of the `h2h` dataset check.
- Styled the chart to blend with CricScope's luxury dark-gold glassmorphism design parameters.

# Testing
- Tested locally by selecting various franchise combinations in `pages/stats.py`.
- Verified that empty matchups are handled gracefully without exceptions.

![Matchup Analytics Dashboard](https://raw.githubusercontent.com/Arnav-Singh-5080/CricScope/main/assets/analytics.png)

# Impact
Restores interactive data exploration capabilities for fans and analysts viewing matches on CricScope.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered