### PR TITLE
docs: add standard templates for PR and issue tracking

### DIFF
--- a/github/ISSUE_TEMPLATE/bug_report.md
+++ b/github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,48 @@
+name: 🐛 Bug report
+description: Create a report to help us improve CricScope
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: describe-bug
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is.
+      placeholder: Describe the problem clearly...
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: Steps to reproduce
+      description: List the exact steps to reproduce the problem.
+      placeholder: |
+        1. Run the app local server
+        2. Go to pages/...
+        3. Click on ...
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen instead?
+      placeholder: Explain what should happen...
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment Info
+      description: Python version, Streamlit version, OS, etc.
+      placeholder: |
+        - OS: Windows/Linux
+        - Python: 3.10
+        - Browser: Chrome/Safari
+    validations:
+      required: false

--- a/github/ISSUE_TEMPLATE/feature_request.md
+++ b/github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,33 @@
+name: 🚀 Feature request
+description: Suggest an idea or enhancement for CricScope
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        We love new feature ideas! Share your proposal with us.
+  - type: textarea
+    id: feature-description
+    attributes:
+      label: Feature Description
+      description: Describe the core enhancement idea.
+      placeholder: What feature are you proposing?
+    validations:
+      required: true
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case & Motivation
+      description: Explain why this is helpful for users or developers.
+      placeholder: Why is this needed?
+    validations:
+      required: true
+  - type: textarea
+    id: alternative-solutions
+    attributes:
+      label: Alternative Solutions Considered
+      description: Any alternative implementations you thought about.
+      placeholder: Did you consider other options?
+    validations:
+      required: false

--- a/github/PULL_REQUEST_TEMPLATE.md
+++ b/github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+# Related Issue
+Closes #
+
+# Summary
+Provide a brief, high-level summary of your pull request's goals and implementation details.
+
+# Changes Made
+- Explain implementation changes clearly
+- File modifications and details
+
+# Testing
+Outline the local verification techniques you followed:
+- [ ] Automated tests run locally (`python test_calculations.py`)
+- [ ] Verified Streamlit server runs with zero exceptions
+- [ ] Mobile responsive layout checked
+
+# Screenshots
+If your pull request modifies styling, layout, or visualizations, include visual proof here.
+
+# Impact
+Why is this contribution valuable to the project?
+
+# Checklist
+- [ ] Code follows project standards and aesthetics
+- [ ] Tested locally and verify build passes
+- [ ] No unrelated commits or changes included
+- [ ] Responsive design verified
+- [ ] Accessibility standards verified


### PR DESCRIPTION
Closes #409 

# Summary
Introduces standardized collaboration structures for CricScope contributors.

# Changes Made
- Created bug report and feature request templates.
- Created descriptive PR templates with structured verification checklists.

# Checklist
- [x] Templates follow project standards
- [x] Tested locally