### PR TITLE
fix: make microphone button positioning responsive (#460)

### DIFF
--- a/voice_input.py
+++ b/voice_input.py
@@ -14,13 +14,28 @@ def voice_input_component() -> str | None:
         /* Container that wraps stAudioInput — move this to bottom bar area */
         div[data-testid="stElementContainer"]:has(div[data-testid="stAudioInput"]) {
             position: fixed !important;
-            bottom:93px !important;
+            bottom: 93px !important;
             right: 210px !important;
             z-index: 99999 !important;
             width: 42px !important;
             height: 42px !important;
             padding: 0 !important;
             margin: 0 !important;
+        }
+
+        /* Responsive positioning for smaller laptops and tablets */
+        @media (max-width: 1024px) {
+            div[data-testid="stElementContainer"]:has(div[data-testid="stAudioInput"]) {
+                right: 10% !important;
+            }
+        }
+
+        /* Responsive positioning for mobile viewports */
+        @media (max-width: 768px) {
+            div[data-testid="stElementContainer"]:has(div[data-testid="stAudioInput"]) {
+                right: 5% !important;
+                bottom: 80px !important;
+            }
         }
 
         div[data-testid="stAudioInput"] {


### PR DESCRIPTION
Closes #460

## Changes
- Updated `voice_input.py` to use CSS media queries for the `stAudioInput` element container.
- Replaced the hardcoded fixed pixel positioning (`right: 210px !important;`) with responsive percentage-based units (`right: 5% !important;` and `right: 10% !important;`) inside `@media` blocks depending on the viewport width.

## Why
On smaller screens, tablets, and mobile devices, a hardcoded `right: 210px` offset pushed the microphone button either completely off the screen or caused it to float awkwardly over other UI components. This fix anchors it cleanly relative to the right side of the screen at all widths!

Contributing under GSSoC'26 🎯
