### PR TITLE
fix: remove unrelated voice_input package and add missing langchain dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,6 @@ seaborn
 plotly
 xgboost
 requests
-voice_input
 groq
+langchain-groq
+langchain-core


### PR DESCRIPTION
## Fixes #<issue-number>

## What changed
- Removed `voice_input` from requirements.txt — it's a local module in this repo, and the line was installing an unrelated PyPI package of the same name
- Added `langchain-groq` and `langchain-core`, which `cricket_agent.py` imports — without them the Chatbot page crashes with ModuleNotFoundError on a fresh install

## Testing
- Fresh virtual environment, `pip install -r requirements.txt`
- Ran `streamlit run application.py` — Chatbot page loads without import errors