### PR TITLE
docs: correct run command to application.py and update project structure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ source venv/bin/activate
 Install Dependencies
 pip install -r requirements.txt
 Run the Application
-streamlit run app.py
+streamlit run application.py
 
 The app will start locally at:
 
@@ -158,32 +158,3 @@ By contributing to this project, you agree that your contributions will be licen
 Thank you for contributing to CricScope!
 
 Your support and contributions help improve the project for the open-source community. 🚀
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -234,15 +234,26 @@ cricscope/
 │
 ├── assets/
 │   ├── dashboard.png
-│   ├── prediction-page.png
 │   ├── analytics.png
-│   
-├── app.py
+│   ├── win-probability-prediction.png
+│   └── cricscope.gif
+│
+├── pages/
+│   ├── live_match.py
+│   └── stats.py
+│
+├── model/
+│   └── feature_engineering.py
+│
+├── application.py
+├── cricket_agent.py
+├── venue_intelligence.py
+├── voice_input.py
+├── test_calculations.py
 ├── matches.csv
 ├── deliveries.csv
 ├── requirements.txt
 └── README.md
-└── demo_.gif
 ```
 
 <br/>
@@ -302,7 +313,7 @@ pip install -r requirements.txt
 
 ```text
 cricscope/
-├── app.py
+├── application.py
 ├── matches.csv
 └── deliveries.csv
 ```
@@ -312,7 +323,7 @@ cricscope/
 ## 5 — Run Application
 
 ```bash
-streamlit run app.py
+streamlit run application.py
 ```
 
 Visit:


### PR DESCRIPTION
## Fixes #<issue-number>

## What changed
- Updated the run command in README.md and CONTRIBUTING.md from `streamlit run app.py` to `streamlit run application.py` — no `app.py` exists in the repo, so the Getting Started steps fail with a file-not-found error
- Updated the Project Structure tree in README.md to match the actual repo layout (added cricket_agent.py, venue_intelligence.py, voice_input.py, pages/, model/)

## Testing
- Verified `streamlit run application.py` starts the app at localhost:8501