### PR TITLE
fix: improve UI accessibility and visual contrast

### DIFF
--- a/application.py
+++ b/application.py
@@ -114,7 +114,7 @@ section[data-testid="stSidebar"] > div {
     font-size: 11px;
     letter-spacing: 2.5px;
     text-transform: uppercase;
-    color: rgba(212,175,55,0.45);
+    color: rgba(212,175,55,0.85);
     font-weight: 400;
 }
 
@@ -128,7 +128,7 @@ section[data-testid="stSidebar"] > div {
     font-size: 10px;
     letter-spacing: 2px;
     text-transform: uppercase;
-    color: rgba(180,160,100,0.35);
+    color: rgba(180,160,100,0.80);
     padding: 14px 32px 8px;
     font-weight: 500;
 }
@@ -140,7 +140,7 @@ section[data-testid="stSidebar"] > div {
     background: transparent;
     border: none;
     border-radius: 0;
-    color: rgba(220,210,180,0.65);
+    color: rgba(220,210,180,0.92);
     font-family: 'DM Sans', sans-serif;
     font-size: 14px;
     font-weight: 400;
@@ -195,7 +195,7 @@ section[data-testid="stSidebar"] > div {
     font-size: 10px;
     letter-spacing: 4px;
     text-transform: uppercase;
-    color: rgba(212,175,55,0.5);
+    color: rgba(212,175,55,0.90);
     margin-bottom: 18px;
     font-weight: 400;
 }
@@ -286,7 +286,7 @@ section[data-testid="stSidebar"] > div {
     font-size: 10px;
     letter-spacing: 1.5px;
     text-transform: uppercase;
-    color: rgba(200,185,140,0.4);
+    color: rgba(200,185,140,0.85);
 }
 
 /* ---- ANALYSIS SECTION ---- */
@@ -305,7 +305,7 @@ section[data-testid="stSidebar"] > div {
 
 .section-desc {
     font-size: 13px;
-    color: rgba(200,185,140,0.4);
+    color: rgba(200,185,140,0.85);
     letter-spacing: 0.3px;
 }
 
@@ -328,7 +328,7 @@ section[data-testid="stSidebar"] > div {
     font-size: 10px;
     letter-spacing: 2px;
     text-transform: uppercase;
-    color: rgba(212,175,55,0.5);
+    color: rgba(212,175,55,0.90);
     margin-bottom: 12px;
     font-weight: 500;
 }
@@ -348,7 +348,7 @@ section[data-testid="stSidebar"] > div {
     font-size: 10px !important;
     letter-spacing: 1.8px !important;
     text-transform: uppercase !important;
-    color: rgba(200,185,140,0.5) !important;
+    color: rgba(200,185,140,0.88) !important;
     font-weight: 500 !important;
 }
 
@@ -393,7 +393,7 @@ section[data-testid="stSidebar"] > div {
     font-family: 'Cormorant Garamond', serif;
     font-size: 48px;
     font-weight: 300;
-    color: rgba(212,175,55,0.25);
+    color: rgba(212,175,55,0.70);
     line-height: 1;
     letter-spacing: -2px;
 }
@@ -461,7 +461,7 @@ section[data-testid="stSidebar"] > div {
     font-size: 9px;
     letter-spacing: 3px;
     text-transform: uppercase;
-    color: rgba(212,175,55,0.4);
+    color: rgba(212,175,55,0.85);
     margin-bottom: 24px;
     font-weight: 500;
 }
@@ -491,7 +491,7 @@ section[data-testid="stSidebar"] > div {
     font-size: 10px;
     letter-spacing: 2px;
     text-transform: uppercase;
-    color: rgba(200,185,140,0.35);
+    color: rgba(200,185,140,0.80);
     margin-bottom: 28px;
 }
 
@@ -513,7 +513,7 @@ section[data-testid="stSidebar"] > div {
     border-radius: 100px;
     background: linear-gradient(90deg, #b8962e, #d4af37, #f0d060);
     transition: width 0.8s cubic-bezier(0.34, 1.56, 0.64, 1);
-    box-shadow: 0 0 12px rgba(212,175,55,0.4);
+    box-shadow: 0 0 12px rgba(212,175,55,0.85);
 }
 
 .prob-bar-labels {
@@ -521,7 +521,7 @@ section[data-testid="stSidebar"] > div {
     justify-content: space-between;
     margin-top: 10px;
     font-size: 11px;
-    color: rgba(200,185,140,0.4);
+    color: rgba(200,185,140,0.85);
     font-family: 'DM Mono', monospace;
     letter-spacing: 0.5px;
 }
@@ -554,7 +554,7 @@ section[data-testid="stSidebar"] > div {
     font-size: 9px;
     letter-spacing: 1.5px;
     text-transform: uppercase;
-    color: rgba(180,165,115,0.35);
+    color: rgba(180,165,115,0.78);
 }
 
 /* ---- STRAY STREAMLIT COMPONENTS ---- */
@@ -604,7 +604,7 @@ hr {
 /* ---- SCROLLBAR ---- */
 ::-webkit-scrollbar { width: 4px; }
 ::-webkit-scrollbar-track { background: #0c0c0c; }
-::-webkit-scrollbar-thumb { background: rgba(212,175,55,0.25); border-radius: 4px; }
+::-webkit-scrollbar-thumb { background: rgba(212,175,55,0.70); border-radius: 4px; }
 
 /* ============================================================
    SIDEBAR PROFILE SECTION - Premium Glassmorphism
@@ -670,7 +670,7 @@ section[data-testid="stSidebar"] a:active {
     font-weight: 700;
     color: #0a0800;
     letter-spacing: 0.5px;
-    box-shadow: 0 0 0 2px rgba(212,175,55,0.25), 0 0 20px rgba(212,175,55,0.25), 0 3px 12px rgba(0,0,0,0.4);
+    box-shadow: 0 0 0 2px rgba(212,175,55,0.70), 0 0 20px rgba(212,175,55,0.70), 0 3px 12px rgba(0,0,0,0.4);
     transition: box-shadow 0.3s ease, transform 0.3s ease;
     position: relative;
     z-index: 1;
@@ -678,7 +678,7 @@ section[data-testid="stSidebar"] a:active {
 }
 
 .profile-card:hover .profile-avatar {
-    box-shadow: 0 0 0 2px rgba(212,175,55,0.45), 0 0 26px rgba(212,175,55,0.35), 0 3px 14px rgba(0,0,0,0.5);
+    box-shadow: 0 0 0 2px rgba(212,175,55,0.85), 0 0 26px rgba(212,175,55,0.35), 0 3px 14px rgba(0,0,0,0.5);
     transform: scale(1.04);
 }
 
@@ -841,11 +841,11 @@ section[data-testid="stSidebar"] a:active {
 }
 .matrix-cell.correct {
     background: rgba(212,175,55,0.06);
-    border: 1px solid rgba(212,175,55,0.25);
+    border: 1px solid rgba(212,175,55,0.70);
 }
 .matrix-cell.correct:hover {
     background: rgba(212,175,55,0.1);
-    border-color: rgba(212,175,55,0.45);
+    border-color: rgba(212,175,55,0.85);
     transform: translateY(-2px);
 }
 .matrix-cell.incorrect {
@@ -1269,7 +1269,7 @@ if st.session_state.page == "Dashboard":
     st.markdown("""
         <div style="padding: 48px 72px;">
             <div style="font-family:'Cormorant Garamond',serif; font-size:13px; letter-spacing:3px;
-                        text-transform:uppercase; color:rgba(212,175,55,0.4); margin-bottom:28px;">
+                        text-transform:uppercase; color:rgba(212,175,55,0.85); margin-bottom:28px;">
                 IPL Teams
             </div>
             <div style="display:flex; flex-wrap:wrap; gap:12px;">
@@ -1300,7 +1300,7 @@ if st.session_state.page == "Dashboard":
                                 color:{tdata['color']}; letter-spacing:2px; margin-top:12px;">
                         {tdata['abbr']}
                     </div>
-                    <div style="font-size:10px; color:rgba(200,185,140,0.35); margin-top:4px;
+                    <div style="font-size:10px; color:rgba(200,185,140,0.80); margin-top:4px;
                                 letter-spacing:0.5px;">
                         {team_name}
                     </div>
@@ -1316,7 +1316,7 @@ if st.session_state.page == "Dashboard":
             <div style="display:inline-block; background:rgba(212,175,55,0.06); border:1px solid rgba(212,175,55,0.15);
                         border-radius:14px; padding:20px 36px;">
                 <div style="font-size:10px;letter-spacing:2px;text-transform:uppercase;
-                            color:rgba(212,175,55,0.5);margin-bottom:8px;">Get Started</div>
+                            color:rgba(212,175,55,0.90);margin-bottom:8px;">Get Started</div>
                 <div style="font-family:'Cormorant Garamond',serif;font-size:20px;color:#f0e8cc;font-weight:500;">
                     Open Match Analysis from the sidebar →
                 </div>
@@ -1497,7 +1497,7 @@ if st.session_state.page == "Analysis":
     # ---- INPUT SECTION ----
     st.markdown("""
         <div style="font-size:10px;letter-spacing:3px;text-transform:uppercase;
-                    color:rgba(212,175,55,0.4);margin-bottom:20px;font-weight:500;">
+                    color:rgba(212,175,55,0.85);margin-bottom:20px;font-weight:500;">
             Match Configuration
         </div>
     """, unsafe_allow_html=True)
@@ -1544,7 +1544,7 @@ if st.session_state.page == "Analysis":
 
     st.markdown("""
         <div style="font-size:10px;letter-spacing:3px;text-transform:uppercase;
-                    color:rgba(212,175,55,0.4);margin-bottom:16px;font-weight:500;">
+                    color:rgba(212,175,55,0.85);margin-bottom:16px;font-weight:500;">
             Fixture
         </div>
     """, unsafe_allow_html=True)
@@ -1687,7 +1687,7 @@ if st.session_state.page == "Analysis":
         st.markdown('<div style="height:28px;"></div>', unsafe_allow_html=True)
         st.markdown("""
             <div style="font-size:10px;letter-spacing:3px;text-transform:uppercase;
-                        color:rgba(212,175,55,0.4);margin-bottom:16px;font-weight:500;">
+                        color:rgba(212,175,55,0.85);margin-bottom:16px;font-weight:500;">
                 Prediction Output
             </div>
         """, unsafe_allow_html=True)
@@ -2084,7 +2084,7 @@ if st.session_state.page == "chabot":
         font-size: 10px;
         letter-spacing: 4px;
         text-transform: uppercase;
-        color: rgba(212,175,55,0.45);
+        color: rgba(212,175,55,0.85);
         margin-bottom: 8px;
         font-weight: 400;
     }
@@ -2160,7 +2160,7 @@ if st.session_state.page == "chabot":
         font-size: 10px;
         letter-spacing: 1.2px;
         text-transform: uppercase;
-        color: rgba(200,185,140,0.4);
+        color: rgba(200,185,140,0.85);
         font-weight: 500;
     }
  
@@ -2365,7 +2365,7 @@ if st.session_state.page == "chabot":
         width: 6px;
         height: 6px;
         border-radius: 50%;
-        background: rgba(212,175,55,0.5);
+        background: rgba(212,175,55,0.90);
         animation: thinking-pulse 1.4s infinite ease-in-out;
     }
  
@@ -2392,7 +2392,7 @@ if st.session_state.page == "chabot":
     }
  
     [data-testid="stChatInput"]:focus-within {
-        border-color: rgba(212,175,55,0.45) !important;
+        border-color: rgba(212,175,55,0.85) !important;
         box-shadow: 0 0 0 3px rgba(212,175,55,0.06) !important;
     }
  
@@ -2420,7 +2420,7 @@ if st.session_state.page == "chabot":
     }
  
     [data-testid="stChatInputSubmitButton"] button:hover {
-        box-shadow: 0 4px 18px rgba(212,175,55,0.4) !important;
+        box-shadow: 0 4px 18px rgba(212,175,55,0.85) !important;
         transform: translateY(-1px) !important;
         filter: brightness(1.1) !important;
     }

--- a/pages/live_match.py
+++ b/pages/live_match.py
@@ -148,7 +148,7 @@ footer { visibility: hidden; }
     font-size: 10px;
     letter-spacing: 4px;
     text-transform: uppercase;
-    color: rgba(212,175,55,0.5);
+    color: rgba(212,175,55,0.90);
     margin-bottom: 14px;
     font-weight: 400;
 }
@@ -220,7 +220,7 @@ footer { visibility: hidden; }
     border-radius: 100px;
     background: linear-gradient(90deg, #b8962e, #d4af37, #f0d060);
     transition: width 0.8s cubic-bezier(0.34, 1.56, 0.64, 1);
-    box-shadow: 0 0 12px rgba(212,175,55,0.4);
+    box-shadow: 0 0 12px rgba(212,175,55,0.85);
 }
 
 .metric-chip {
@@ -242,7 +242,7 @@ footer { visibility: hidden; }
     font-size: 9px;
     letter-spacing: 1.5px;
     text-transform: uppercase;
-    color: rgba(180,165,115,0.35);
+    color: rgba(180,165,115,0.78);
 }
 
 /* ---- MATCH CARD ---- */
@@ -256,7 +256,7 @@ footer { visibility: hidden; }
     transition: all 0.25s ease;
 }
 .match-card:hover {
-    border-color: rgba(212,175,55,0.25);
+    border-color: rgba(212,175,55,0.70);
     background: rgba(212,175,55,0.04);
     transform: translateY(-1px);
 }
@@ -282,14 +282,14 @@ footer { visibility: hidden; }
 /* ---- SCROLLBAR ---- */
 ::-webkit-scrollbar { width: 4px; }
 ::-webkit-scrollbar-track { background: #0c0c0c; }
-::-webkit-scrollbar-thumb { background: rgba(212,175,55,0.25); border-radius: 4px; }
+::-webkit-scrollbar-thumb { background: rgba(212,175,55,0.70); border-radius: 4px; }
 
 /* ---- SECTION LABEL ---- */
 .section-label {
     font-size: 10px;
     letter-spacing: 3px;
     text-transform: uppercase;
-    color: rgba(212,175,55,0.4);
+    color: rgba(212,175,55,0.85);
     margin-bottom: 16px;
     font-weight: 500;
 }
@@ -702,7 +702,7 @@ if not user_api_key:
         st.markdown('<div class="glass-card">', unsafe_allow_html=True)
         st.markdown(
             '<div style="font-size:10px;letter-spacing:2px;text-transform:uppercase;'
-            'color:rgba(212,175,55,0.5);margin-bottom:12px;font-weight:500;">Teams</div>',
+            'color:rgba(212,175,55,0.90);margin-bottom:12px;font-weight:500;">Teams</div>',
             unsafe_allow_html=True,
         )
         demo_bat = st.selectbox("Batting Team", all_teams, key="demo_bat")
@@ -718,7 +718,7 @@ if not user_api_key:
         st.markdown('<div class="glass-card">', unsafe_allow_html=True)
         st.markdown(
             '<div style="font-size:10px;letter-spacing:2px;text-transform:uppercase;'
-            'color:rgba(212,175,55,0.5);margin-bottom:12px;font-weight:500;">Match State</div>',
+            'color:rgba(212,175,55,0.90);margin-bottom:12px;font-weight:500;">Match State</div>',
             unsafe_allow_html=True,
         )
         demo_target = st.number_input("Target", min_value=50, max_value=300, value=185, key="demo_target")
@@ -746,13 +746,13 @@ if not user_api_key:
                     st.markdown(f"""
                         <div class="prediction-card">
                             <div style="font-size:9px;letter-spacing:3px;text-transform:uppercase;
-                                        color:rgba(212,175,55,0.4);margin-bottom:8px;font-weight:500;">
+                                        color:rgba(212,175,55,0.85);margin-bottom:8px;font-weight:500;">
                                 Batting · {bat_data['abbr']}</div>
                             <div style="font-family:'Cormorant Garamond',serif;font-size:22px;
                                         font-weight:500;color:#c8b870;margin-bottom:12px;">{demo_bat}</div>
                             <div class="win-probability">{result['batting_win']}%</div>
                             <div style="font-size:10px;letter-spacing:2px;text-transform:uppercase;
-                                        color:rgba(200,185,140,0.35);margin-bottom:16px;">Win Probability</div>
+                                        color:rgba(200,185,140,0.80);margin-bottom:16px;">Win Probability</div>
                             <div class="prob-bar-track">
                                 <div class="prob-bar-fill" style="width:{result['batting_win']}%;"></div>
                             </div>
@@ -778,7 +778,7 @@ if not user_api_key:
                         <div style="background:rgba(255,255,255,0.02);border:1px solid rgba(255,255,255,0.07);
                                     border-radius:24px;padding:36px 32px;position:relative;overflow:hidden;">
                             <div style="font-size:9px;letter-spacing:3px;text-transform:uppercase;
-                                        color:rgba(212,175,55,0.4);margin-bottom:8px;font-weight:500;">
+                                        color:rgba(212,175,55,0.85);margin-bottom:8px;font-weight:500;">
                                 Bowling · {bowl_data['abbr']}</div>
                             <div style="font-family:'Cormorant Garamond',serif;font-size:22px;
                                         font-weight:500;color:#c8b870;margin-bottom:12px;">{demo_bowl}</div>
@@ -786,7 +786,7 @@ if not user_api_key:
                                         color:rgba(200,185,140,0.55);line-height:1;margin-bottom:4px;">
                                 {result['bowling_win']}%</div>
                             <div style="font-size:10px;letter-spacing:2px;text-transform:uppercase;
-                                        color:rgba(200,185,140,0.35);margin-bottom:16px;">Win Probability</div>
+                                        color:rgba(200,185,140,0.80);margin-bottom:16px;">Win Probability</div>
                             <div class="prob-bar-track">
                                 <div style="height:100%;border-radius:100px;background:rgba(200,185,140,0.2);
                                             width:{result['bowling_win']}%;transition:width 0.8s ease;"></div>
@@ -918,7 +918,7 @@ else:
                             <div style="font-family:'Cormorant Garamond',serif;font-size:32px;
                                         font-weight:600;color:{t1_display['color']};letter-spacing:2px;">
                                 {t1_display['abbr']}</div>
-                            <div style="font-size:11px;color:rgba(200,185,140,0.4);margin-top:4px;">
+                            <div style="font-size:11px;color:rgba(200,185,140,0.85);margin-top:4px;">
                                 {team1_name}</div>
                         </div>
                         <div style="font-family:'Cormorant Garamond',serif;font-size:36px;
@@ -927,7 +927,7 @@ else:
                             <div style="font-family:'Cormorant Garamond',serif;font-size:32px;
                                         font-weight:600;color:{t2_display['color']};letter-spacing:2px;">
                                 {t2_display['abbr']}</div>
-                            <div style="font-size:11px;color:rgba(200,185,140,0.4);margin-top:4px;">
+                            <div style="font-size:11px;color:rgba(200,185,140,0.85);margin-top:4px;">
                                 {team2_name}</div>
                         </div>
                     </div>
@@ -949,10 +949,10 @@ else:
                     st.markdown(f"""
                         <div class="glass-card" style="text-align:center;">
                             <div style="font-size:10px;letter-spacing:1.5px;text-transform:uppercase;
-                                        color:rgba(200,185,140,0.4);margin-bottom:8px;">{inning_name}</div>
+                                        color:rgba(200,185,140,0.85);margin-bottom:8px;">{inning_name}</div>
                             <div style="font-family:'DM Mono',monospace;font-size:28px;
                                         color:#e8d89a;font-weight:500;">{inning_score}</div>
-                            <div style="font-size:12px;color:rgba(200,185,140,0.35);
+                            <div style="font-size:12px;color:rgba(200,185,140,0.80);
                                         margin-top:4px;">({inning_overs} Ov)</div>
                         </div>
                     """, unsafe_allow_html=True)
@@ -1009,14 +1009,14 @@ else:
                         st.markdown(f"""
                             <div class="prediction-card">
                                 <div style="font-size:9px;letter-spacing:3px;text-transform:uppercase;
-                                            color:rgba(212,175,55,0.4);margin-bottom:8px;font-weight:500;">
+                                            color:rgba(212,175,55,0.85);margin-bottom:8px;font-weight:500;">
                                     Chasing · {bat_display['abbr']}</div>
                                 <div style="font-family:'Cormorant Garamond',serif;font-size:20px;
                                             font-weight:500;color:#c8b870;margin-bottom:12px;">
                                     {batting_2nd}</div>
                                 <div class="win-probability">{result['batting_win']}%</div>
                                 <div style="font-size:10px;letter-spacing:2px;text-transform:uppercase;
-                                            color:rgba(200,185,140,0.35);margin-bottom:16px;">
+                                            color:rgba(200,185,140,0.80);margin-bottom:16px;">
                                     Win Probability</div>
                                 <div class="prob-bar-track">
                                     <div class="prob-bar-fill" style="width:{result['batting_win']}%;"></div>
@@ -1045,7 +1045,7 @@ else:
                                         border:1px solid rgba(255,255,255,0.07);
                                         border-radius:24px;padding:36px 32px;">
                                 <div style="font-size:9px;letter-spacing:3px;text-transform:uppercase;
-                                            color:rgba(212,175,55,0.4);margin-bottom:8px;font-weight:500;">
+                                            color:rgba(212,175,55,0.85);margin-bottom:8px;font-weight:500;">
                                     Defending · {bowl_display['abbr']}</div>
                                 <div style="font-family:'Cormorant Garamond',serif;font-size:20px;
                                             font-weight:500;color:#c8b870;margin-bottom:12px;">
@@ -1054,7 +1054,7 @@ else:
                                             color:rgba(200,185,140,0.55);line-height:1;margin-bottom:4px;">
                                     {result['bowling_win']}%</div>
                                 <div style="font-size:10px;letter-spacing:2px;text-transform:uppercase;
-                                            color:rgba(200,185,140,0.35);margin-bottom:16px;">
+                                            color:rgba(200,185,140,0.80);margin-bottom:16px;">
                                     Win Probability</div>
                                 <div class="prob-bar-track">
                                     <div style="height:100%;border-radius:100px;

--- a/pages/stats.py
+++ b/pages/stats.py
@@ -73,7 +73,7 @@ section[data-testid="stSidebar"] > div {
     font-size: 10px;
     letter-spacing: 4px;
     text-transform: uppercase;
-    color: rgba(212,175,55,0.5);
+    color: rgba(212,175,55,0.90);
     margin-bottom: 18px;
     font-weight: 400;
 }
@@ -116,7 +116,7 @@ section[data-testid="stSidebar"] > div {
 
 .section-desc {
     font-size: 13px;
-    color: rgba(200,185,140,0.4);
+    color: rgba(200,185,140,0.85);
     letter-spacing: 0.3px;
 }
 
@@ -181,7 +181,7 @@ section[data-testid="stSidebar"] > div {
     font-size: 10px !important;
     letter-spacing: 1.8px !important;
     text-transform: uppercase !important;
-    color: rgba(200,185,140,0.5) !important;
+    color: rgba(200,185,140,0.88) !important;
     font-weight: 500 !important;
 }
 
@@ -202,7 +202,7 @@ hr {
 /* ---- SCROLLBAR ---- */
 ::-webkit-scrollbar { width: 4px; }
 ::-webkit-scrollbar-track { background: #0c0c0c; }
-::-webkit-scrollbar-thumb { background: rgba(212,175,55,0.25); border-radius: 4px; }
+::-webkit-scrollbar-thumb { background: rgba(212,175,55,0.70); border-radius: 4px; }
 </style>
 """, unsafe_allow_html=True)
 
@@ -239,7 +239,7 @@ st.markdown('<div style="padding: 0 60px 60px;">', unsafe_allow_html=True)
 st.markdown('<div style="height:40px;"></div>', unsafe_allow_html=True)
 st.markdown("""
 <div style="font-size:10px;letter-spacing:3px;text-transform:uppercase;
-            color:rgba(212,175,55,0.4);margin-bottom:8px;font-weight:500;">
+            color:rgba(212,175,55,0.85);margin-bottom:8px;font-weight:500;">
     Head-to-Head Record
 </div>
 <div class="section-title">⚔️ Team Matchup</div>
@@ -320,7 +320,7 @@ else:
     # recent 5 matches
     st.markdown("""
     <div style="font-size:10px;letter-spacing:2px;text-transform:uppercase;
-                color:rgba(212,175,55,0.4);margin:24px 0 12px;font-weight:500;">
+                color:rgba(212,175,55,0.85);margin:24px 0 12px;font-weight:500;">
         Recent Encounters
     </div>
     """, unsafe_allow_html=True)
@@ -337,7 +337,7 @@ st.markdown('<div style="height:1px; background:linear-gradient(90deg, transpare
 # SECTION 2 — Top Run Scorers & Wicket Takers per Team 
 st.markdown("""
 <div style="font-size:10px;letter-spacing:3px;text-transform:uppercase;
-            color:rgba(212,175,55,0.4);margin-bottom:8px;font-weight:500;">
+            color:rgba(212,175,55,0.85);margin-bottom:8px;font-weight:500;">
     Player Performance by Team
 </div>
 <div class="section-title">🏏 Top Performers</div>
@@ -379,7 +379,7 @@ with col_bat:
     st.markdown(f"""
     <div class="glass-card" style="padding:20px 24px; margin-bottom:16px;">
         <div style="font-size:10px; letter-spacing:2px; text-transform:uppercase;
-                    color:rgba(212,175,55,0.5); font-weight:500;">
+                    color:rgba(212,175,55,0.90); font-weight:500;">
             Top Run Scorers — {selected_team}
         </div>
     </div>
@@ -387,7 +387,7 @@ with col_bat:
 
     for i, row in top_batters.iterrows():
         bar_pct = int(row["Runs"] / top_batters["Runs"].max() * 100)
-        rank_color = "#d4af37" if i == 0 else "rgba(200,185,140,0.35)"
+        rank_color = "#d4af37" if i == 0 else "rgba(200,185,140,0.80)"
         st.markdown(f"""
         <div style="display:flex; align-items:center; margin-bottom:0.5rem; gap:0.8rem;">
             <span style="color:{rank_color}; font-family:'DM Mono',monospace; font-size:11px; width:1.4rem;">#{i+1}</span>
@@ -407,7 +407,7 @@ with col_bowl:
     st.markdown(f"""
     <div class="glass-card" style="padding:20px 24px; margin-bottom:16px;">
         <div style="font-size:10px; letter-spacing:2px; text-transform:uppercase;
-                    color:rgba(212,175,55,0.5); font-weight:500;">
+                    color:rgba(212,175,55,0.90); font-weight:500;">
             Top Wicket Takers — {selected_team}
         </div>
     </div>
@@ -415,7 +415,7 @@ with col_bowl:
 
     for i, row in top_bowlers.iterrows():
         bar_pct = int(row["Wickets"] / top_bowlers["Wickets"].max() * 100)
-        rank_color = "#d4af37" if i == 0 else "rgba(200,185,140,0.35)"
+        rank_color = "#d4af37" if i == 0 else "rgba(200,185,140,0.80)"
         st.markdown(f"""
         <div style="display:flex; align-items:center; margin-bottom:0.5rem; gap:0.8rem;">
             <span style="color:{rank_color}; font-family:'DM Mono',monospace; font-size:11px; width:1.4rem;">#{i+1}</span>
@@ -437,7 +437,7 @@ st.markdown('<div style="height:1px; background:linear-gradient(90deg, transpare
 
 st.markdown("""
 <div style="font-size:10px;letter-spacing:3px;text-transform:uppercase;
-            color:rgba(212,175,55,0.4);margin-bottom:8px;font-weight:500;">
+            color:rgba(212,175,55,0.85);margin-bottom:8px;font-weight:500;">
     Venue Performance
 </div>
 <div class="section-title">🏟️ Ground Analysis</div>
@@ -465,7 +465,7 @@ venue_stats = venue_stats.sort_values("Played", ascending=False).head(10)
 
 st.markdown(f"""
 <div style="font-size:10px;letter-spacing:2px;text-transform:uppercase;
-            color:rgba(212,175,55,0.4);margin:24px 0 16px;font-weight:500;">
+            color:rgba(212,175,55,0.85);margin:24px 0 16px;font-weight:500;">
     Top venues by matches played — {venue_team}
 </div>
 """, unsafe_allow_html=True)
@@ -487,7 +487,7 @@ for _, row in venue_stats.iterrows():
         <div class="win-bar-wrap">
             <div style="height:6px; border-radius:100px; width:{win_pct}%;
                         background:linear-gradient(90deg, {bar_color}, #f0d060);
-                        box-shadow:0 0 8px rgba(212,175,55,0.25);"></div>
+                        box-shadow:0 0 8px rgba(212,175,55,0.70);"></div>
         </div>
     </div>
     """, unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
Fixes low contrast UI elements across the application as described in #479.

## Problem
Several UI elements had low opacity text (as low as 0.25–0.45) against the dark background, making them difficult to read and failing basic accessibility standards.

## Changes Made
- Increased opacity on low-contrast text elements in `application.py`, `pages/stats.py`, and `pages/live_match.py`
- Sidebar section labels: `0.35` → `0.80`
- Nav button text: `0.65` → `0.92`
- Stat/card labels: `0.40` → `0.85`
- Gold accent text: `0.25` → `0.70`, `0.45` → `0.85`
- No design system or color changes — only opacity values adjusted to maintain existing aesthetic

## Benefits
- Better readability across all screen sizes
- Improved accessibility compliance (WCAG 2.1)
- More professional and polished interface
- Easier information consumption

## Files Changed
- `application.py`
- `pages/stats.py`
- `pages/live_match.py`

Closes #479