### PR TITLE
Fix Cricket Assistant module import error causing application crash (#478)

### DIFF
--- a/application.py
+++ b/application.py
@@ -2544,7 +2544,13 @@ if st.session_state.page == "chabot":
         last_msg = st.session_state.chat_messages[-1]
 
         if last_msg["role"] == "user":
-            from cricket_agent import run_agent
+            try:
+                from cricket_agent import run_agent
+                chatbot_available = True
+
+            except Exception as e:
+                chatbot_available = False
+                chatbot_error = str(e)
             try:
                 response_text = run_agent(
                     user_message=last_msg["content"],

--- a/cricket_agent.py
+++ b/cricket_agent.py
@@ -1,5 +1,8 @@
 import streamlit as st
-from langchain_groq import ChatGroq
+try:
+    from langchain_groq import ChatGroq
+except ImportError:
+    ChatGroq = None
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 from langchain_core.messages import HumanMessage, AIMessage, SystemMessage
 from langchain_core.output_parsers import StrOutputParser
@@ -43,18 +46,62 @@ RESPONSE STYLE:
 
 
 @st.cache_resource
+@st.cache_resource
 def get_chain():
     """
     Build and cache the LCEL chain:
         prompt | llm | output_parser
+
     Cached so the LLM isn't re-instantiated on every Streamlit rerun.
     """
+
+    if ChatGroq is None:
+        raise RuntimeError(
+            "langchain-groq is not installed.\n"
+            "Run:\n"
+            "pip install langchain-groq"
+        )
+
     try:
         api_key = st.secrets["groq"]["key"]
-    except KeyError:
-        raise RuntimeError(
-            "Groq API key missing.\n"
+
+    except Exception:
+        st.error("⚠️ Groq API key not found.")
+
+        st.info(
+            "Create .streamlit/secrets.toml"
         )
+
+        st.code(
+            """
+[groq]
+key = "YOUR_GROQ_API_KEY"
+"""
+        )
+
+        st.stop()
+
+    if not api_key:
+        st.error("⚠️ Empty Groq API key.")
+        st.stop()
+
+    llm = ChatGroq(
+        groq_api_key=api_key,
+        model_name="llama-3.1-8b-instant",
+        temperature=0.7,
+        max_tokens=1024,
+    )
+
+    prompt = ChatPromptTemplate.from_messages([
+        ("system", SYSTEM_PROMPT),
+        MessagesPlaceholder(variable_name="history"),
+        ("human", "{question}"),
+    ])
+
+    chain = prompt | llm | StrOutputParser()
+
+    return chain
+    
 
     llm = ChatGroq(
         groq_api_key=api_key,

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ xgboost
 requests
 voice_input
 groq
+langchain-groq
+python-dotenv


### PR DESCRIPTION
## Summary

This PR fixes Issue #478, where the Cricket Assistant (Chatbot) module failed to load due to dependency and configuration issues.

### Changes made

* Added safe handling for missing `langchain-groq` dependency.
* Improved error handling for missing Groq API keys.
* Prevented the entire application from crashing when chatbot dependencies are unavailable.
* Added user-friendly error messages.
* Updated dependency requirements.

### Testing

* Verified application launches successfully.
* Verified Cricket Assistant loads correctly when API keys are configured.
* Verified the app displays graceful error messages when configuration is missing.
* Verified the rest of the application remains functional even if the chatbot is unavailable.

Closes #478
