### PR TITLE
fix: replace unsafe CRR/RRR division with safe_divide utility

### DIFF
--- a/application.py
+++ b/application.py
@@ -37,6 +37,7 @@ from sklearn.model_selection import train_test_split, cross_val_score
 from sklearn.metrics import accuracy_score, precision_score, recall_score, f1_score, confusion_matrix
 from sklearn.ensemble import RandomForestClassifier
 from xgboost import XGBClassifier
+from utils import safe_divide
 
 logging.basicConfig(level=logging.INFO)
 
@@ -1157,8 +1158,8 @@ def generate_ball_by_ball_df(pipe, batting_team, bowling_team, selected_city, ta
 def safe_calculate_rates(score, target, overs):
     runs_left = target - score
     balls_left = max(120 - (overs * 6), 0)
-    crr = score / overs if overs > 0 else 0.0
-    rrr = (runs_left * 6) / balls_left if balls_left > 0 else 0.0
+    crr = safe_divide(score, overs)
+    rrr = safe_divide(runs_left * 6, balls_left)
     return runs_left, balls_left, crr, rrr
 
 # -----------------------------------
@@ -1830,8 +1831,8 @@ if st.session_state.page == "Analysis":
                 b_left = 120 - total_balls_done
                 c_score = score  # score stays same (projection from current state)
                 r_left = target - c_score
-                c_crr = c_score / (total_balls_done / 6) if total_balls_done > 0 else 0
-                c_rrr = (r_left * 6) / b_left if b_left > 0 else 0
+                c_crr = safe_divide(c_score, total_balls_done / 6)
+                c_rrr = safe_divide(r_left * 6, b_left)
 
                 proj_df = pd.DataFrame({
                     'batting_team': [batting_team],

--- a/pages/live_match.py
+++ b/pages/live_match.py
@@ -18,6 +18,7 @@ from sklearn.compose import ColumnTransformer
 from sklearn.preprocessing import OneHotEncoder
 from sklearn.linear_model import LogisticRegression
 from sklearn.pipeline import Pipeline
+from utils import safe_divide
 
 # ───────────────────────────────────────────
 #  PAGE CONFIG
@@ -563,8 +564,8 @@ def compute_prediction(batting_team, bowling_team, venue, target,
             balls_left = 1  # avoid division by zero at end of innings
 
         wickets_in_hand = 10 - wickets_fallen
-        crr = current_score / (total_balls_bowled / 6) if total_balls_bowled > 0 else 0
-        rrr = (runs_left * 6) / balls_left if balls_left > 0 else 0
+        crr = safe_divide(current_score, total_balls_bowled / 6)
+        rrr = safe_divide(runs_left * 6, balls_left)
 
         # Use a generic city if venue is unknown
         city = venue if venue else "Mumbai"

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+EPSILON = 1e-9
+MAX_CRICKET_RATE = 36.0
+
+def safe_divide(numerator: float, denominator: float,
+                default: float = 0.0) -> float:
+    """
+    Safe division with floating-point tolerance
+    and cricket-specific bounds checking.
+    """
+    if abs(denominator) < EPSILON:
+        return default
+    result = numerator / denominator
+    if not np.isfinite(result):
+        return default
+    return float(np.clip(result, 0.0, MAX_CRICKET_RATE))


### PR DESCRIPTION
# Fix: Floating-Point Precision Risk in CRR/RRR Calculations
 
## Summary
 
Fixes a precision bug in CRR/RRR calculations where `> 0` guards failed to catch floating-point noise (e.g. `1e-10` instead of exact `0`), allowing unrealistic rate values to silently reach the ML model.
 
## Problem
 
Three locations computed CRR/RRR using direct `> 0` checks before dividing:
 
- `safe_calculate_rates()` in `application.py`
- CSV export loop in `application.py`
- `compute_prediction()` in `pages/live_match.py`
These checks don't account for near-zero floats produced by cumulative arithmetic or parsed live-API over values, which could inflate CRR/RRR into the millions and feed bad data into the prediction pipeline without raising an error.
 
## Fix
 
Added a shared `safe_divide` utility in `utils.py`:
 
```python
EPSILON = 1e-9
MAX_CRICKET_RATE = 36.0  # 6 sixes/over = physical ceiling
 
def safe_divide(numerator: float, denominator: float, default: float = 0.0) -> float:
    if abs(denominator) < EPSILON:
        return default
    result = numerator / denominator
    if not np.isfinite(result):
        return default
    return float(np.clip(result, 0.0, MAX_CRICKET_RATE))
```
 
## Changes
 
- [x] Add `utils.py` with `safe_divide`, `EPSILON`, and `MAX_CRICKET_RATE`
- [x] Fix `safe_calculate_rates()` in `application.py`
- [x] Fix CSV export loop in `application.py`
- [x] Fix `compute_prediction()` in `pages/live_match.py`
## Testing
 
Manually verified via `streamlit run application.py`:
 
<img width="1917" height="910" alt="image" src="https://github.com/user-attachments/assets/bd6636d1-80ac-4de1-85d8-f85b029b299d" />

<img width="1918" height="905" alt="Screenshot 2026-06-18 201744" src="https://github.com/user-attachments/assets/c2d62161-4e1e-4b03-8fd3-4f5b7b1c3e9a" />

 
All cases returned finite values within `[0.0, 36.0]`, with no crashes, `inf`, or `NaN`.
 
## Related Issue
 
Closes #542