### PR TITLE
fix: chatbot typo, API error message, and dead code removal

### DIFF
--- a/application.py
+++ b/application.py
@@ -1185,7 +1185,7 @@ with st.sidebar:
         st.session_state.page = "Performance"
 
     if st.button("✦  Chatbot", key="nav_chatbot"):
-        st.session_state.page = "chabot"
+        st.session_state.page = "chatbot"
         
     st.markdown('<div class="sidebar-divider"></div>', unsafe_allow_html=True)
     st.markdown('<div class="sidebar-section-label">Model Configuration</div>', unsafe_allow_html=True)
@@ -2044,7 +2044,7 @@ if st.session_state.page == "Team Analysis":
         if st.button("⬅ Back to Dashboard"):
             st.session_state.page = "Dashboard"
             st.rerun()
-if st.session_state.page == "chabot":
+if st.session_state.page == "chatbot":
  
     # ---- Init session state ----
     if "chat_messages" not in st.session_state:

--- a/cricket_agent.py
+++ b/cricket_agent.py
@@ -69,14 +69,9 @@ def get_chain():
         st.error("⚠️ Groq API key not found.")
 
         st.info(
-            "Create .streamlit/secrets.toml"
-        )
-
-        st.code(
-            """
-[groq]
-key = "YOUR_GROQ_API_KEY"
-"""
+            "To enable the chatbot, create a `.streamlit/secrets.toml` file in the project root with:\n\n"
+            "```toml\n[groq]\nkey = \"YOUR_GROQ_API_KEY\"\n```\n\n"
+            "Get your free API key at https://console.groq.com"
         )
 
         st.stop()
@@ -102,23 +97,6 @@ key = "YOUR_GROQ_API_KEY"
 
     return chain
     
-
-    llm = ChatGroq(
-        groq_api_key=api_key,
-        model_name="llama-3.1-8b-instant",
-        temperature=0.7,
-        max_tokens=1024,
-    )
-
-    prompt = ChatPromptTemplate.from_messages([
-        ("system", SYSTEM_PROMPT),
-        MessagesPlaceholder(variable_name="history"),   # sliding window injected here
-        ("human", "{question}"),
-    ])
-
-    chain = prompt | llm | StrOutputParser()
-    return chain
-
 
 
 


### PR DESCRIPTION
Fixes #547

- Fixed typo: "chabot" → "chatbot" causing chatbot page to not render
- Improved API key error message with clear setup instructions and Groq console link
- Removed duplicate st.code block
- Removed unreachable dead code in get_chain()