### PR TITLE
Fix Groq chatbot config flow end-to-end

### DIFF
--- a/.streamlit/secrets.toml.example
+++ b/.streamlit/secrets.toml.example
@@ -1,0 +1,2 @@
+[groq]
+key = "YOUR_GROQ_API_KEY"

--- a/application.py
+++ b/application.py
@@ -2561,15 +2561,18 @@ if st.session_state.page == "chatbot":
             except Exception as e:
                 chatbot_available = False
                 chatbot_error = str(e)
-            try:
-                response_text = run_agent(
-                    user_message=last_msg["content"],
-                    chat_history=st.session_state.chat_messages[:-1],
-                )
-            except RuntimeError as e:
-                response_text = f"⚠️ Configuration error: {str(e)}"
-            except Exception as e:
-                response_text = f"⚠️ Something went wrong: {str(e)}"
+            if not chatbot_available:
+                response_text = f"⚠️ Chatbot unavailable: {chatbot_error}"
+            else:
+                try:
+                    response_text = run_agent(
+                        user_message=last_msg["content"],
+                        chat_history=st.session_state.chat_messages[:-1],
+                    )
+                except RuntimeError as e:
+                    response_text = f"⚠️ Configuration error: {str(e)}"
+                except Exception as e:
+                    response_text = f"⚠️ Something went wrong: {str(e)}"
 
             st.session_state.chat_messages.append({
                 "role":    "assistant",

--- a/cricket_agent.py
+++ b/cricket_agent.py
@@ -1,4 +1,6 @@
+import os
 import streamlit as st
+
 try:
     from langchain_groq import ChatGroq
 except ImportError:
@@ -7,6 +9,12 @@ from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 from langchain_core.messages import HumanMessage, AIMessage, SystemMessage
 from langchain_core.output_parsers import StrOutputParser
 
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except ImportError:
+    pass
 
 
 SYSTEM_PROMPT = """You are CricScope's AI Cricket Assistant — a knowledgeable, 
@@ -43,9 +51,6 @@ RESPONSE STYLE:
   politely redirect back to cricket."""
 
 
-
-
-@st.cache_resource
 @st.cache_resource
 def get_chain():
     """
@@ -57,27 +62,25 @@ def get_chain():
 
     if ChatGroq is None:
         raise RuntimeError(
-            "langchain-groq is not installed.\n"
-            "Run:\n"
-            "pip install langchain-groq"
+            "langchain-groq is not installed.\n" "Run:\n" "pip install langchain-groq"
         )
-
     try:
         api_key = st.secrets["groq"]["key"]
-
     except Exception:
-        st.error("⚠️ Groq API key not found.")
+        api_key = os.environ.get("GROQ_API_KEY")
+
+    if not api_key:
+        st.error(" Groq API key not found.")
 
         st.info(
-            "To enable the chatbot, create a `.streamlit/secrets.toml` file in the project root with:\n\n"
-            "```toml\n[groq]\nkey = \"YOUR_GROQ_API_KEY\"\n```\n\n"
+            "To enable the chatbot, either:\n\n"
+            "**Option A —** create a `.streamlit/secrets.toml` file in the project root with:\n"
+            '```toml\n[groq]\nkey = "YOUR_GROQ_API_KEY"\n```\n\n'
+            "**Option B —** create a `.env` file in the project root with:\n"
+            "```\nGROQ_API_KEY=YOUR_GROQ_API_KEY\n```\n\n"
             "Get your free API key at https://console.groq.com"
         )
 
-        st.stop()
-
-    if not api_key:
-        st.error("⚠️ Empty Groq API key.")
         st.stop()
 
     llm = ChatGroq(
@@ -87,17 +90,17 @@ def get_chain():
         max_tokens=1024,
     )
 
-    prompt = ChatPromptTemplate.from_messages([
-        ("system", SYSTEM_PROMPT),
-        MessagesPlaceholder(variable_name="history"),
-        ("human", "{question}"),
-    ])
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            ("system", SYSTEM_PROMPT),
+            MessagesPlaceholder(variable_name="history"),
+            ("human", "{question}"),
+        ]
+    )
 
     chain = prompt | llm | StrOutputParser()
 
     return chain
-    
-
 
 
 def _build_history(chat_history: list[dict], window: int = 6) -> list:
@@ -109,11 +112,11 @@ def _build_history(chat_history: list[dict], window: int = 6) -> list:
     Only the last `window` turns are kept to avoid token overflow.
     """
     # Take the last N messages (window * 2 covers N full turns)
-    recent = chat_history[-(window * 2):]
+    recent = chat_history[-(window * 2) :]
 
     lc_messages = []
     for msg in recent:
-        role    = msg.get("role", "")
+        role = msg.get("role", "")
         content = msg.get("content", "")
         if role == "user":
             lc_messages.append(HumanMessage(content=content))
@@ -121,8 +124,6 @@ def _build_history(chat_history: list[dict], window: int = 6) -> list:
             lc_messages.append(AIMessage(content=content))
 
     return lc_messages
-
-
 
 
 def run_agent(user_message: str, chat_history: list[dict]) -> str:
@@ -142,10 +143,12 @@ def run_agent(user_message: str, chat_history: list[dict]) -> str:
     history = _build_history(chat_history)
 
     try:
-        response = chain.invoke({
-            "history":  history,
-            "question": user_message,
-        })
+        response = chain.invoke(
+            {
+                "history": history,
+                "question": user_message,
+            }
+        )
         return response
 
     except Exception as e:
@@ -160,4 +163,3 @@ def run_agent(user_message: str, chat_history: list[dict]) -> str:
             return "⚠️ Request timed out. Please try again."
         else:
             return f"⚠️ Something went wrong: {str(e)}"
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ seaborn
 plotly
 xgboost
 requests
-voice_input
 groq
 langchain-groq
 python-dotenv

--- a/voice_input.py
+++ b/voice_input.py
@@ -5,11 +5,13 @@ voice_input.py - uses CSS transform to reposition without breaking click target
 import streamlit as st
 from groq import Groq
 import hashlib
+import os
 
 
 def voice_input_component() -> str | None:
 
-    st.markdown("""
+    st.markdown(
+        """
         <style>
         /* Container that wraps stAudioInput — move this to bottom bar area */
         div[data-testid="stElementContainer"]:has(div[data-testid="stAudioInput"]) {
@@ -346,7 +348,9 @@ div[data-testid="stAudioInput"] > div > *:not(button):not(:has(button)) {
     z-index: -1 !important;
 }
         </style>
-    """, unsafe_allow_html=True)
+    """,
+        unsafe_allow_html=True,
+    )
 
     if "last_audio_hash" not in st.session_state:
         st.session_state.last_audio_hash = None
@@ -361,7 +365,7 @@ div[data-testid="stAudioInput"] > div > *:not(button):not(:has(button)) {
         return None
 
     audio_bytes = audio.read()
-    audio_hash  = hashlib.md5(audio_bytes).hexdigest()
+    audio_hash = hashlib.md5(audio_bytes).hexdigest()
 
     if audio_hash == st.session_state.last_audio_hash:
         return None
@@ -370,8 +374,11 @@ div[data-testid="stAudioInput"] > div > *:not(button):not(:has(button)) {
 
     try:
         api_key = st.secrets["groq"]["key"]
-    except KeyError:
-        st.warning("⚠️ Groq key missing in secrets.toml")
+    except Exception:
+        api_key = os.environ.get("GROQ_API_KEY")
+
+    if not api_key:
+        st.warning("⚠️ Groq key missing in secrets.toml or as GROQ_API_KEY env var.")
         return None
 
     with st.spinner("Transcribing…"):


### PR DESCRIPTION
Closes #556

- Removed a duplicate @st.cache_resource decorator in cricket_agent.py
- Added GROQ_API_KEY env var as a fallback to st.secrets, so the chatbot
  works whether you use secrets.toml or a .env file
- Fixed application.py: the chatbot_available flag was computed but never
  checked, so an import failure caused a confusing NameError instead of a
  clean error message
- Fixed voice_input.py: it only caught KeyError, but Streamlit raises
  StreamlitSecretNotFoundError when secrets.toml doesn't exist at all, so
  The friendly warning never showed on a fresh clone
- Removed an erroneous "voice_input" line from requirements.txt (it
  resolves to an unrelated PyPI package, not the local voice_input.py)
- Added .streamlit/secrets.toml.example and documented Groq setup in README