### PR TITLE
fix: handle failed chatbot imports gracefully without NameError

### DIFF
--- a/application.py
+++ b/application.py
@@ -2557,19 +2557,22 @@ if st.session_state.page == "chabot":
             try:
                 from cricket_agent import run_agent
                 chatbot_available = True
-
             except Exception as e:
                 chatbot_available = False
                 chatbot_error = str(e)
-            try:
-                response_text = run_agent(
-                    user_message=last_msg["content"],
-                    chat_history=st.session_state.chat_messages[:-1],
-                )
-            except RuntimeError as e:
-                response_text = f"⚠️ Configuration error: {str(e)}"
-            except Exception as e:
-                response_text = f"⚠️ Something went wrong: {str(e)}"
+
+            if chatbot_available:
+                try:
+                    response_text = run_agent(
+                        user_message=last_msg["content"],
+                        chat_history=st.session_state.chat_messages[:-1],
+                    )
+                except RuntimeError as e:
+                    response_text = f"⚠️ Configuration error: {str(e)}"
+                except Exception as e:
+                    response_text = f"⚠️ Something went wrong: {str(e)}"
+            else:
+                response_text = f"⚠️ Chatbot is unavailable: {chatbot_error}"
 
             st.session_state.chat_messages.append({
                 "role":    "assistant",


### PR DESCRIPTION
# Description

This PR fixes an application crash (NameError) that occurs when importing the `cricket_agent` module fails in the Chatbot section. 

Currently, if the import of `cricket_agent` fails due to missing dependencies, invalid API keys, or missing secrets, the code catches the exception but immediately proceeds to call `run_agent()` anyway. Because `run_agent` was never imported, this throws a `NameError: name 'run_agent' is not defined`, hiding the original import/configuration error.

This PR adds a conditional check on `chatbot_available` before calling `run_agent()`. If the chatbot is unavailable, the user receives a descriptive configuration error message instead of an application crash.

## Related Issues
- Fixes the crash caused by failed imports in the Chatbot page.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] The chatbot error state displays correctly in the UI instead of raising a `NameError`

# Screenshots / UI State (Optional)
When the import fails, the chatbot now displays:
> ⚠️ Chatbot is unavailable: [Original Import/Configuration Error details]
