### PR TITLE
fix: add train/test split in train_model() to prevent overfitting (cl…

### DIFF
--- a/pages/live_match.py
+++ b/pages/live_match.py
@@ -448,7 +448,8 @@ def train_model():
         ('model', LogisticRegression(max_iter=1000))
     ])
 
-    pipe.fit(X, y)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+        pipe.fit(X_train, y_train)
     return pipe
 
 


### PR DESCRIPTION
Fixes #237

## Summary

`train_model()` in `pages/live_match.py` was calling `pipe.fit(X, y)` on 100% of the data with no evaluation. This means the model was trained without any held-out test set.

## Changes
- Added `train_test_split` to split data 80/20
- - Changed `pipe.fit(X, y)` to `pipe.fit(X_train, y_train)` so the model is trained only on the training portion