### PR TITLE
fix: resolve StreamlitValueAboveMaxError when Target Score is set to 50

### DIFF
--- a/application.py
+++ b/application.py
@@ -1680,7 +1680,7 @@ if st.session_state.page == "Analysis":
         st.markdown('<div class="input-card">', unsafe_allow_html=True)
         st.markdown('<div class="input-label">Match State</div>', unsafe_allow_html=True)
         target = st.number_input("Target Score", min_value=50, max_value=300, value=180, step=1)
-        score = st.number_input("Current Score", min_value=0, max_value=target - 1, value=50, step=1)
+        score = st.number_input("Current Score", min_value=0, max_value=target - 1, value=min(50,target-1), step=1)
         col_ov, col_wk = st.columns(2)
         with col_ov:
             overs = st.slider("Overs Completed", min_value=0, max_value=20, value=10)


### PR DESCRIPTION
## Summary
Fixes #576

## Bug
When Target Score is set to 50, max_value for Current Score becomes 49 
but default value was hardcoded to 50, causing StreamlitValueAboveMaxError crash.

## Fix
Changed value=50 to value=min(50, target - 1) so default value 
dynamically stays within bounds.

## Changes
- application.py line 1683: value=min(50, target - 1)

## Tested
- Target = 50 → default current score = 49 ✅
- Target = 180 → default current score = 50 ✅