### PR TITLE
fix: replace hardcoded head-to-head stats and pie chart with dynamic …

### DIFF
--- a/pages/stats.py
+++ b/pages/stats.py
@@ -252,27 +252,7 @@ with col2:
     remaining = [t for t in all_teams if t != team_a]
     team_b = st.selectbox("Team B", remaining, index=remaining.index("Chennai Super Kings") if "Chennai Super Kings" in remaining else 0, key="h2h_b")
     
-#Example value
-team_a = "Chennai Super KIngs"
-team_b = "Mumbai Indians"
-
-team_a_wins = 11
-team_b_wins = 17
-
-#Pie Chart
-fig = go.Figure(data=[go.Pie(
-    labels=[f"{team_a}Wins",f"{team_b}Wins"],
-    values=[11,17],
-    hole=0.5
-)])
-
-fig.update_layout(
-    paper_bgcolor="#0E1117",
-    font_color="white",
-    margin=dict(l=20,r=20,t=20,b=20))
-
-st.plotly_chart(fig, use_container_width=True)
-# filter h2h matches
+# filter h2h matches dynamically from selected teams
 h2h = matches[
     ((matches["team1"] == team_a) & (matches["team2"] == team_b)) |
     ((matches["team1"] == team_b) & (matches["team2"] == team_a))
@@ -288,6 +268,22 @@ else:
 
     a_pct = round(a_wins / total * 100, 1) if total else 0
     b_pct = round(b_wins / total * 100, 1) if total else 0
+
+    fig = go.Figure(data=[go.Pie(
+        labels=[f"{team_a} Wins", f"{team_b} Wins"],
+        values=[a_wins, b_wins],
+        hole=0.5,
+        marker=dict(colors=["#d4af37", "#8b5e3c"]),
+        textfont=dict(color="white"),
+    )])
+    fig.update_layout(
+        paper_bgcolor="rgba(0,0,0,0)",
+        plot_bgcolor="rgba(0,0,0,0)",
+        font_color="white",
+        margin=dict(l=20, r=20, t=20, b=20),
+        legend=dict(font=dict(color="rgba(200,185,140,0.85)")),
+    )
+    st.plotly_chart(fig, use_container_width=True)
 
     ca, cb, cc = st.columns(3)
     with ca:


### PR DESCRIPTION
Fixes #476

Removed hardcoded team names and win counts (Chennai Super Kings / Mumbai Indians, 11/17) 
that were overriding the UI selectors. Replaced with dynamic calculation from the matches 
dataset based on the user's team selection.

Changes:
- Deleted hardcoded team_a, team_b, team_a_wins, team_b_wins variables
- Pie chart now uses values=[a_wins, b_wins] computed from filtered h2h matches
- Chart and stats refresh automatically when team selection changes
- Edge case handled: shows info message when no h2h matches exist