### PR TITLE
fix: use linear score projection in ball-by-ball simulation, keep wic…

### DIFF
--- a/application.py
+++ b/application.py
@@ -1973,7 +1973,9 @@ if st.session_state.page == "Analysis":
                     break
 
                 b_left = 120 - total_balls_done
-                c_score = score  # score stays same (projection from current state)
+                # Project score linearly; wickets held constant (fall timing unknown)
+                balls_played = overs * 6
+                c_score = int(score * total_balls_done / balls_played) if balls_played > 0 else score
                 r_left = target - c_score
                 c_crr = c_score / (total_balls_done / 6) if total_balls_done > 0 else 0
                 c_rrr = (r_left * 6) / b_left if b_left > 0 else 0


### PR DESCRIPTION
Fixes #428

The generate_ball_by_ball_df function was holding c_score constant 
at the current score for all future balls, causing c_crr to grow 
incorrectly as total_balls_done increased without any runs being added.

Fixed by projecting score linearly from the current state forward, 
while keeping wickets constant (since wicket fall timing cannot be 
reconstructed retroactively from user-supplied inputs).