### PR TITLE
docs: fix documentation anchor link in table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Built with a fintech-inspired dark UI featuring glassmorphism cards, gold gradie
 
 ## Table of Contents 
 - [Live Demo](#live-demo)
-- [CricScope Documentation](#cricscope-documentation)
+- [CricScope Documentation](#documentation)
 - [Architecture](#architecture)
 - [Model Evaluation Metrics](#model-evaluation-metrics)
 - [Dataset Split](#dataset-split)


### PR DESCRIPTION
## Description
Fixed a broken anchor link for the Documentation section in the Table of Contents of `README.md`.

## Why this is needed
The Table of Contents link pointed to `(#cricscope-documentation)`, but the actual heading further down the page is `## 📚 Documentation`, which GitHub automatically translates to just `(#documentation)`. Because of this mismatch, clicking the link in the TOC did nothing.

## Changes Made
- Updated the Table of Contents anchor link from `(#cricscope-documentation)` to `(#documentation)` so the jump-link works correctly.